### PR TITLE
Fix postgres timeouts

### DIFF
--- a/src/integrations/postgres/index.ts
+++ b/src/integrations/postgres/index.ts
@@ -1,6 +1,6 @@
 import { RaidHubPool, RaidHubPoolTransaction } from "./pool"
 
-export const postgres = new RaidHubPool({
+export const postgres = new RaidHubPool("readonly", {
     user: process.env.POSTGRES_USER,
     password: process.env.POSTGRES_PASSWORD,
     database: "raidhub",
@@ -10,7 +10,7 @@ export const postgres = new RaidHubPool({
     idleTimeoutMillis: 30000
 })
 
-export const postgresWritable = new RaidHubPoolTransaction({
+export const postgresWritable = new RaidHubPoolTransaction("writable", {
     user: process.env.POSTGRES_WRITABLE_USER,
     password: process.env.POSTGRES_WRITABLE_PASSWORD,
     database: "raidhub",

--- a/src/integrations/postgres/index.ts
+++ b/src/integrations/postgres/index.ts
@@ -5,8 +5,8 @@ export const postgres = new RaidHubPool({
     password: process.env.POSTGRES_PASSWORD,
     database: "raidhub",
     min: process.env.PROD ? 5 : 1,
-    max: process.env.PROD ? 100 : 10,
-    acquireTimeoutMillis: 10000,
+    max: process.env.PROD ? 150 : 10,
+    acquireTimeoutMillis: 1000,
     idleTimeoutMillis: 30000
 })
 
@@ -14,6 +14,12 @@ export const postgresWritable = new RaidHubPoolTransaction({
     user: process.env.POSTGRES_WRITABLE_USER,
     password: process.env.POSTGRES_WRITABLE_PASSWORD,
     database: "raidhub",
-    min: 1,
-    max: 3
+    min: 0,
+    max: process.env.PROD ? 15 : 3,
+    minIdle: 0,
+    maxQueue: 100,
+    acquireMaxRetries: 2,
+    acquireRetryWait: 1000,
+    idleTimeoutMillis: 500,
+    houseKeepInterval: 500
 })

--- a/src/integrations/postgres/pool.ts
+++ b/src/integrations/postgres/pool.ts
@@ -135,4 +135,8 @@ class RaidHubStatement {
 
         return (rows ?? []) as unknown[]
     }
+
+    async close() {
+        await this.stmnt.close()
+    }
 }

--- a/src/integrations/postgres/pool.ts
+++ b/src/integrations/postgres/pool.ts
@@ -6,6 +6,7 @@ import {
     QueryOptions,
     ScriptExecuteOptions
 } from "postgresql-client"
+import { postgresConnectionsGauge } from "../prometheus/metrics"
 
 interface RaidHubQuerier {
     queryRow<T>(sql: string, options?: Omit<QueryOptions, "objectRows">): Promise<T | null>
@@ -17,9 +18,19 @@ interface RaidHubQuerier {
 }
 
 export class RaidHubPool extends Pool implements RaidHubQuerier {
-    private connector: RaidHubConnector = new RaidHubConnector(this)
-    constructor(config?: PoolConfiguration | string) {
+    readonly metricLabel: string
+    readonly metricsInterval: Timer
+    private readonly connector: RaidHubConnector = new RaidHubConnector(this)
+
+    constructor(metricLabel: string, config?: PoolConfiguration | string) {
         super(config)
+        this.metricLabel = metricLabel
+
+        this.metricsInterval = setInterval(() => {
+            this.updateGauge("total")
+            this.updateGauge("idle")
+            this.updateGauge("acquired")
+        }, 5000)
     }
 
     async queryRow<T>(sql: string, options?: Omit<QueryOptions, "objectRows">): Promise<T | null> {
@@ -34,6 +45,33 @@ export class RaidHubPool extends Pool implements RaidHubQuerier {
     }
     async prepareStatement(sql: string) {
         return await this.connector.prepareStatement(sql)
+    }
+
+    private updateGauge(label: "total" | "idle" | "acquired") {
+        let value: number
+        switch (label) {
+            case "total":
+                value = this.totalConnections
+                break
+            case "idle":
+                value = this.idleConnections
+                break
+            case "acquired":
+                value = this.acquiredConnections
+                break
+        }
+
+        postgresConnectionsGauge.set(
+            {
+                connection_state: label,
+                pool_name: this.metricLabel
+            },
+            value
+        )
+    }
+
+    [Symbol.dispose]() {
+        clearInterval(this.metricsInterval)
     }
 }
 

--- a/src/integrations/prometheus/metrics.ts
+++ b/src/integrations/prometheus/metrics.ts
@@ -1,4 +1,4 @@
-import { Histogram } from "prom-client"
+import { Gauge, Histogram } from "prom-client"
 
 export const httpRequestTimer = new Histogram({
     name: "incoming_api_request_duration_ms",
@@ -28,4 +28,10 @@ export const playerSearchQueryTimer = new Histogram({
     help: "Duration of player search queries in ms",
     labelNames: ["prefixLength"],
     buckets: QueryBuckets
+})
+
+export const postgresConnectionsGauge = new Gauge({
+    name: "postgres_connections",
+    labelNames: ["pool_name", "connection_state"],
+    help: "Number of PostgreSQL connections in the pool and their states"
 })

--- a/src/integrations/prometheus/registry.ts
+++ b/src/integrations/prometheus/registry.ts
@@ -3,7 +3,8 @@ import {
     activityHistoryQueryTimer,
     httpRequestTimer,
     playerProfileQueryTimer,
-    playerSearchQueryTimer
+    playerSearchQueryTimer,
+    postgresConnectionsGauge
 } from "./metrics"
 
 export const prometheusRegistry = new Registry()
@@ -12,3 +13,4 @@ prometheusRegistry.registerMetric(httpRequestTimer)
 prometheusRegistry.registerMetric(activityHistoryQueryTimer)
 prometheusRegistry.registerMetric(playerProfileQueryTimer)
 prometheusRegistry.registerMetric(playerSearchQueryTimer)
+prometheusRegistry.registerMetric(postgresConnectionsGauge)

--- a/src/services/reporting/update-blacklist.ts
+++ b/src/services/reporting/update-blacklist.ts
@@ -35,6 +35,8 @@ export const blacklistInstance = async (data: {
                 })
             )
         )
+
+        void playerStmnt.close()
     })
 }
 


### PR DESCRIPTION
This pull request introduces several enhancements and adjustments to the PostgreSQL integration, focusing on connection pool management, monitoring, and resource cleanup. It also includes updates to Prometheus metrics for better observability.

### PostgreSQL Connection Pool Enhancements:
* Updated `RaidHubPool` to include a `metricLabel` and a periodic metrics collection mechanism using a new `updateGauge` method, which tracks total, idle, and acquired connections. These metrics are reported to Prometheus via the new `postgresConnectionsGauge`. (`src/integrations/postgres/pool.ts`, [[1]](diffhunk://#diff-ecff155cf04cb6d9043c4ed404a59b689bd34fb7a96c6605487de39d8f559fcaL20-R33) [[2]](diffhunk://#diff-ecff155cf04cb6d9043c4ed404a59b689bd34fb7a96c6605487de39d8f559fcaR49-R75)
* Modified connection pool configurations in `index.ts` to support more dynamic and fine-tuned connection management, including new parameters like `minIdle`, `maxQueue`, and retry settings. (`src/integrations/postgres/index.ts`, [src/integrations/postgres/index.tsL3-R24](diffhunk://#diff-0f81c1888942100778744b3ed964dde200ff9ebc889fc8e14372858ed53c22b7L3-R24))

### Prometheus Metrics Integration:
* Added a new `Gauge` metric, `postgresConnectionsGauge`, to monitor PostgreSQL connection states (total, idle, acquired) across pools. (`src/integrations/prometheus/metrics.ts`, [src/integrations/prometheus/metrics.tsR32-R37](diffhunk://#diff-44aa5645e6fbdc19ba17f8744967574c97d57577fb0d6a5e349ae64f6eee9d53R32-R37))
* Registered the new `postgresConnectionsGauge` in the Prometheus registry for observability. (`src/integrations/prometheus/registry.ts`, [[1]](diffhunk://#diff-eda32a5f45e9c25a0b89db43e67be53d66955c7f9e187576a858541a6caf0fa1L6-R7) [[2]](diffhunk://#diff-eda32a5f45e9c25a0b89db43e67be53d66955c7f9e187576a858541a6caf0fa1R16)

### Resource Cleanup:
* Implemented a `[Symbol.dispose]` method in `RaidHubPool` to clear the metrics interval when the pool is disposed of, ensuring proper cleanup of resources. (`src/integrations/postgres/pool.ts`, [src/integrations/postgres/pool.tsR49-R75](diffhunk://#diff-ecff155cf04cb6d9043c4ed404a59b689bd34fb7a96c6605487de39d8f559fcaR49-R75))
* Added an asynchronous `close` method to `RaidHubStatement` for explicitly closing prepared statements. (`src/integrations/postgres/pool.ts`, [src/integrations/postgres/pool.tsR176-R179](diffhunk://#diff-ecff155cf04cb6d9043c4ed404a59b689bd34fb7a96c6605487de39d8f559fcaR176-R179))
* Ensured the `playerStmnt` statement is closed after use in the blacklist update service. (`src/services/reporting/update-blacklist.ts`, [src/services/reporting/update-blacklist.tsR38-R39](diffhunk://#diff-9e7b78af69adb6bb3b42cd389c447b5afb73451eea46d441f2feb3412fc1fb46R38-R39))