### PR TITLE
update global leaderboard routes

### DIFF
--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "RaidHub API",
     "description": "The Semi-public API for RaidHub",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "contact": {
       "name": "RaidHub Admin",
       "email": "admin@raidhub.io"
@@ -1290,6 +1290,17 @@
             },
             "required": ["type", "format", "page", "count", "entries"]
           }
+        ]
+      },
+      "IndividualGlobalLeaderboardCategory": {
+        "type": "string",
+        "enum": [
+          "clears",
+          "full-clears",
+          "sherpas",
+          "speedrun",
+          "world-first-rankings",
+          "in-raid-time"
         ]
       },
       "LeaderboardPagination": {
@@ -5453,14 +5464,7 @@
         "parameters": [
           {
             "schema": {
-              "type": "string",
-              "enum": [
-                "clears",
-                "freshClears",
-                "sherpas",
-                "speedrun",
-                "powerRankings"
-              ]
+              "$ref": "#/components/schemas/IndividualGlobalLeaderboardCategory"
             },
             "required": true,
             "name": "category",

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,1 @@
-export const apiVersion = "1.3.1"
+export const apiVersion = "1.3.2"

--- a/src/routes/leaderboard/individual/global.test.ts
+++ b/src/routes/leaderboard/individual/global.test.ts
@@ -25,6 +25,16 @@ describe("global leaderboard 200", () => {
                 page: 1
             }
         ))
+    test("full clears", () =>
+        t(
+            {
+                category: "full-clears"
+            },
+            {
+                count: 10,
+                page: 1
+            }
+        ))
 
     test("sherpas", () =>
         t(
@@ -34,6 +44,17 @@ describe("global leaderboard 200", () => {
             {
                 count: 14,
                 page: 4
+            }
+        ))
+
+    test("in raid time", () =>
+        t(
+            {
+                category: "in-raid-time"
+            },
+            {
+                count: 19,
+                page: 7
             }
         ))
 
@@ -51,7 +72,7 @@ describe("global leaderboard 200", () => {
     test("power rankings", () =>
         t(
             {
-                category: "powerRankings"
+                category: "world-first-rankings"
             },
             {
                 count: 14,
@@ -62,7 +83,7 @@ describe("global leaderboard 200", () => {
     test("search power rankings", () =>
         t(
             {
-                category: "powerRankings"
+                category: "world-first-rankings"
             },
             {
                 count: 11,

--- a/src/routes/leaderboard/individual/global.ts
+++ b/src/routes/leaderboard/individual/global.ts
@@ -2,6 +2,7 @@ import { RaidHubRoute } from "@/core/RaidHubRoute"
 import { cacheControl } from "@/middleware/cache-control"
 import { zLeaderboardData } from "@/schema/components/LeaderboardData"
 import { ErrorCode } from "@/schema/errors/ErrorCode"
+import { zIndividualGlobalLeaderboardCategory } from "@/schema/params/IndividualGlobalLeaderboardCategory"
 import { zLeaderboardPagination } from "@/schema/query/LeaderboardPagination"
 import { zBigIntString } from "@/schema/util"
 import {
@@ -14,20 +15,11 @@ import {
 } from "@/services/leaderboard/individual/power-rankings"
 import { z } from "zod"
 
-const zCategory = z.enum(["clears", "freshClears", "sherpas", "speedrun", "powerRankings"])
-
-const categoryMap = {
-    clears: "clears",
-    freshClears: "fresh_clears",
-    sherpas: "sherpas",
-    speedrun: "speed"
-} as const
-
 export const leaderboardIndividualGlobalRoute = new RaidHubRoute({
     method: "get",
     description: `Individual leaderboards across all raids`,
     params: z.object({
-        category: zCategory
+        category: zIndividualGlobalLeaderboardCategory
     }),
     query: zLeaderboardPagination,
     response: {
@@ -52,7 +44,7 @@ export const leaderboardIndividualGlobalRoute = new RaidHubRoute({
         const { page, count, search } = req.query
 
         if (search) {
-            const data = await (category === "powerRankings"
+            const data = await (category === "world-first-rankings"
                 ? searchIndividualWorldFirstPowerRankingsLeaderboard({
                       membershipId: search,
                       take: count
@@ -60,7 +52,7 @@ export const leaderboardIndividualGlobalRoute = new RaidHubRoute({
                 : searchIndividualGlobalLeaderboard({
                       membershipId: search,
                       take: count,
-                      column: categoryMap[category]
+                      category
                   }))
 
             if (!data) {
@@ -77,7 +69,7 @@ export const leaderboardIndividualGlobalRoute = new RaidHubRoute({
                 entries: data.entries
             })
         } else {
-            const entries = await (category === "powerRankings"
+            const entries = await (category === "world-first-rankings"
                 ? getIndividualWorldFirstPowerRankingsLeaderboard({
                       skip: (page - 1) * count,
                       take: count
@@ -85,7 +77,7 @@ export const leaderboardIndividualGlobalRoute = new RaidHubRoute({
                 : getIndividualGlobalLeaderboard({
                       skip: (page - 1) * count,
                       take: count,
-                      column: categoryMap[category]
+                      category
                   }))
 
             return RaidHubRoute.ok({

--- a/src/schema/params/IndividualGlobalLeaderboardCategory.ts
+++ b/src/schema/params/IndividualGlobalLeaderboardCategory.ts
@@ -1,0 +1,10 @@
+import { registry } from "@/schema/registry"
+import { z } from "zod"
+
+export type IndividualGlobalLeaderboardCategory = z.infer<
+    typeof zIndividualGlobalLeaderboardCategory
+>
+export const zIndividualGlobalLeaderboardCategory = registry.register(
+    "IndividualGlobalLeaderboardCategory",
+    z.enum(["clears", "full-clears", "sherpas", "speedrun", "world-first-rankings", "in-raid-time"])
+)

--- a/src/services/leaderboard/global.test.ts
+++ b/src/services/leaderboard/global.test.ts
@@ -12,7 +12,7 @@ describe("getIndividualGlobalLeaderboard", () => {
         const data = await getIndividualGlobalLeaderboard({
             skip: 24921,
             take: 27,
-            column: "clears"
+            category: "clears"
         }).catch(console.error)
 
         const parsed = z.array(zIndividualLeaderboardEntry).safeParse(data)
@@ -30,7 +30,7 @@ describe("searchIndividualGlobalLeaderboard", () => {
     it("returns the correct shape", async () => {
         const data = await searchIndividualGlobalLeaderboard({
             take: 4,
-            column: "clears",
+            category: "clears",
             membershipId: "4611686018488107374"
         }).catch(console.error)
 


### PR DESCRIPTION
This pull request introduces changes to the RaidHub API to enhance the handling of individual global leaderboard categories. It refactors the category management system to use a centralized schema, adds new leaderboard categories, and updates the corresponding test cases and service logic. These changes improve maintainability and extend functionality.

### API Enhancements:
* Updated the API version from `1.3.1` to `1.3.2` in `openapi.json` and `src/core/version.ts`. [[1]](diffhunk://#diff-52abeb91025adb011c4f12d88880430a5838d0fe9e748b09d0b98c4434acb637L6-R6) [[2]](diffhunk://#diff-2c6181f24588358a8fcf9fdd972060bfbdc238f0809f01de3d54d9f0bad35c5cL1-R1)
* Added a new schema `IndividualGlobalLeaderboardCategory` to define valid leaderboard categories, including new ones like `full-clears`, `world-first-rankings`, and `in-raid-time`. [[1]](diffhunk://#diff-52abeb91025adb011c4f12d88880430a5838d0fe9e748b09d0b98c4434acb637R1295-R1305) [[2]](diffhunk://#diff-8d1f2de9d7c13d7cc10ec3769f6f6b6fee9b40c60a79c22507aad144ab82f94cR1-R10)
* Replaced inline category definitions in the API specification with references to the new schema.

### Service Refactoring:
* Centralized category mapping logic in `src/services/leaderboard/individual/global.ts` using a `categoryMap` and `getColumn` function to validate and map categories.
* Updated service methods (`getIndividualGlobalLeaderboard` and `searchIndividualGlobalLeaderboard`) to use `category` instead of `column`, improving clarity and consistency. [[1]](diffhunk://#diff-0c2e3b9e19a45e122eed83bc90f1b8e24772a29e730e97a68dbd512c09ed8ab0L59-R77) [[2]](diffhunk://#diff-0c2e3b9e19a45e122eed83bc90f1b8e24772a29e730e97a68dbd512c09ed8ab0L85-R97)

### Test Updates:
* Added new test cases for the new leaderboard categories (`full-clears`, `in-raid-time`). [[1]](diffhunk://#diff-322e200cf59e1062b4ca6a3bd3d3e81fa88e5bd544fdbea4b51a0d5e854b6bc7R28-R37) [[2]](diffhunk://#diff-322e200cf59e1062b4ca6a3bd3d3e81fa88e5bd544fdbea4b51a0d5e854b6bc7R50-R60)
* Updated existing test cases to reflect changes in category naming, replacing `powerRankings` with `world-first-rankings`. [[1]](diffhunk://#diff-322e200cf59e1062b4ca6a3bd3d3e81fa88e5bd544fdbea4b51a0d5e854b6bc7L54-R75) [[2]](diffhunk://#diff-322e200cf59e1062b4ca6a3bd3d3e81fa88e5bd544fdbea4b51a0d5e854b6bc7L65-R86)

### Code Simplification:
* Removed redundant inline category definitions in `src/routes/leaderboard/individual/global.ts` and replaced them with the new schema `zIndividualGlobalLeaderboardCategory`.
* Simplified query construction in leaderboard services by directly using the category parameter. [[1]](diffhunk://#diff-5977cca3724fe7a74e070709cfe84d45d99968441e903ee5d898ee831ee05c2fL55-R55) [[2]](diffhunk://#diff-5977cca3724fe7a74e070709cfe84d45d99968441e903ee5d898ee831ee05c2fL80-R80)