### PR TITLE
Instance Standing Bug Fixes

### DIFF
--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -634,7 +634,8 @@
                   "type": "string"
                 },
                 "individualReason": {
-                  "type": "string"
+                  "type": "string",
+                  "nullable": true
                 },
                 "createdAt": {
                   "type": "string",

--- a/src/schema/components/InstanceStanding.ts
+++ b/src/schema/components/InstanceStanding.ts
@@ -142,7 +142,7 @@ export const zInstancePlayerStanding = registry.register(
                 instanceId: zInt64(),
                 instanceDate: zISODateString(),
                 reason: z.string(),
-                individualReason: z.string(),
+                individualReason: z.string().nullable(),
                 createdAt: zISODateString()
             })
         ),

--- a/src/services/reporting/standing.test.ts
+++ b/src/services/reporting/standing.test.ts
@@ -53,4 +53,19 @@ describe("getInstancePlayersStanding", () => {
             expect(parsed.success).toBe(true)
         }
     })
+
+    it("returns the correct shape #2", async () => {
+        const standing = await getInstancePlayersStanding("16327328028")
+        expect(standing.length).toBe(6)
+        expect(standing[1].playerInfo.membershipId).toBe("4611686018470558748")
+        expect(standing[1].blacklistedInstances.length).toBeGreaterThan(0)
+
+        const parsed = z.array(zInstancePlayerStanding).safeParse(standing)
+        if (!parsed.success) {
+            console.error(parsed.error.errors)
+            expect(parsed.error.errors).toEqual([])
+        } else {
+            expect(parsed.success).toBe(true)
+        }
+    })
 })

--- a/src/services/reporting/standing.ts
+++ b/src/services/reporting/standing.ts
@@ -89,31 +89,32 @@ export const getInstancePlayersStanding = async (instanceId: bigint | string) =>
                         'flaggedAt', fip.flagged_at
                     ) AS "data"
                     FROM flag_instance_player fip
-                    JOIN instance i ON i.instance_id = fip.instance_id
+                    JOIN instance i USING (instance_id)
                     WHERE fip.membership_id = p.membership_id 
                         AND fip.instance_id <> $1::bigint
-                    ORDER BY date_trunc('week', fip.flagged_at) DESC, fip.cheat_probability DESC
-                    LIMIT 10
+                    ORDER BY (fip.cheat_probability - EXTRACT(EPOCH FROM (NOW() - i.date_started)) / 86400 / 365) DESC
+                    LIMIT 15
                 ) AS f
             ) AS "otherRecentFlags",
             (
                 SELECT COALESCE(jsonb_agg(b.data), '[]'::jsonb)
                 FROM (
                     SELECT json_build_object(
-                        'instanceId', bip.instance_id,
+                        'instanceId', bi.instance_id::text,
                         'individualReason', bip.reason,
                         'reason', bi.reason,
                         'createdAt', bi.created_at,
                         'instanceDate', i.date_started
                     ) AS "data"
-                    FROM blacklist_instance_player bip
-                    JOIN instance i ON i.instance_id = bip.instance_id
-                    JOIN blacklist_instance bi ON bi.instance_id = bip.instance_id
-                    WHERE bip.membership_id = p.membership_id
-                        AND bip.instance_id <> $1::bigint
-                        AND i.date_started < NOW() - INTERVAL '6 months'
-                    ORDER BY bip.instance_id DESC
-                    LIMIT 10
+                    FROM blacklist_instance bi 
+                    JOIN instance i ON i.instance_id = bi.instance_id
+                    JOIN instance_player ip ON ip.instance_id = bi.instance_id AND ip.membership_id = p.membership_id
+                    LEFT JOIN blacklist_instance_player bip ON bi.instance_id = bip.instance_id 
+                        AND bip.membership_id = p.membership_id
+                    WHERE bi.instance_id <> $1::bigint
+                        AND NOT (bi.report_source = 'BlacklistedPlayerCascade' AND bip.membership_id IS NOT NULL)
+                    ORDER BY i.date_started DESC
+                    LIMIT 15
                 ) AS b
             ) AS "blacklistedInstances"
         FROM instance_player ip


### PR DESCRIPTION
This pull request introduces updates to the `InstanceStanding` schema, test cases, and the SQL queries in the `getInstancePlayersStanding` function to enhance functionality and improve data accuracy. The most significant changes include making the `individualReason` field nullable, adding a new test case, and optimizing SQL queries for better performance and data filtering.

### Schema Updates:
* Updated the `zInstancePlayerStanding` schema to allow the `individualReason` field to be nullable, ensuring compatibility with records where this field might not be present. (`src/schema/components/InstanceStanding.ts`, [src/schema/components/InstanceStanding.ts](diffhunk://#diff-7aa18bde96f1f86beb86b5a930be943ad412e4b70f66e49cc291c054906a5fbaL145-R145))

### Test Enhancements:
* Added a new test case to validate the shape and correctness of the `getInstancePlayersStanding` function's output, including checks for array length, specific membership IDs, and parsed schema validation. (`src/services/reporting/standing.test.ts`, [src/services/reporting/standing.test.ts](diffhunk://#diff-94a875c5554ca1adcfabdbf4102e38da4f6c7f8d3d2f8a3e96895baa8380aeb2R56-R70))

### SQL Query Optimizations:
* Modified the `getInstancePlayersStanding` function:
  - Replaced `JOIN ... ON` with `USING` for cleaner SQL syntax in certain joins. (`src/services/reporting/standing.ts`, [src/services/reporting/standing.ts](diffhunk://#diff-3cc1b2eb48cfefd54a71fbd82678a1cc18e320349c89884bd24d203a36527f88L92-R117))
  - Updated the sorting logic for flagged instances, incorporating cheat probability and time decay to prioritize more recent and relevant flags. (`src/services/reporting/standing.ts`, [src/services/reporting/standing.ts](diffhunk://#diff-3cc1b2eb48cfefd54a71fbd82678a1cc18e320349c89884bd24d203a36527f88L92-R117))
  - Adjusted the blacklist query to refine filtering logic, exclude certain cascaded blacklist entries, and increase the result limit from 10 to 15 for both flagged and blacklisted instances. (`src/services/reporting/standing.ts`, [src/services/reporting/standing.ts](diffhunk://#diff-3cc1b2eb48cfefd54a71fbd82678a1cc18e320349c89884bd24d203a36527f88L92-R117))