### PR TITLE
Fix reprised raid, non-challenge not getting contest

### DIFF
--- a/src/services/instance/instance.test.ts
+++ b/src/services/instance/instance.test.ts
@@ -51,6 +51,36 @@ describe("getInstance", () => {
                 expect(parsed.data.isWeekOne).toBe(true)
             }
         })
+
+        it("is contest for day 1 non-challenge king's fall", async () => {
+            const data = await getInstance("11395499732").catch(console.error)
+
+            const parsed = zInstance.safeParse(data)
+            if (!parsed.success) {
+                console.error(parsed.error.errors)
+                expect(parsed.error.errors).toEqual([])
+            } else {
+                expect(parsed.success).toBe(true)
+                expect(parsed.data.isContest).toBe(true)
+                expect(parsed.data.isDayOne).toBe(true)
+                expect(parsed.data.isWeekOne).toBe(true)
+            }
+        })
+
+        it("is not contest for day 1 levi", async () => {
+            const data = await getInstance("258758374").catch(console.error)
+
+            const parsed = zInstance.safeParse(data)
+            if (!parsed.success) {
+                console.error(parsed.error.errors)
+                expect(parsed.error.errors).toEqual([])
+            } else {
+                expect(parsed.success).toBe(true)
+                expect(parsed.data.isContest).toBe(false)
+                expect(parsed.data.isDayOne).toBe(true)
+                expect(parsed.data.isWeekOne).toBe(true)
+            }
+        })
     })
 })
 

--- a/src/services/instance/instance.ts
+++ b/src/services/instance/instance.ts
@@ -23,8 +23,8 @@ export async function getInstance(instanceId: bigint | string): Promise<Instance
             season_id AS "season",
             duration AS "duration",
             platform_type AS "platformType",
-            CASE WHEN av.is_world_first THEN date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') ELSE false END AS "isDayOne",
-            CASE WHEN av.is_world_first THEN date_completed < COALESCE(contest_end, TIMESTAMP 'epoch') ELSE false END AS "isContest",
+            CASE WHEN av.is_contest_eligible THEN date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') ELSE false END AS "isDayOne",
+            CASE WHEN av.is_contest_eligible THEN date_completed < COALESCE(contest_end, TIMESTAMP 'epoch') ELSE false END AS "isContest",
             date_completed < COALESCE(week_one_end, TIMESTAMP 'epoch') AS "isWeekOne",
             b.instance_id IS NOT NULL AS "isBlacklisted"
         FROM instance

--- a/src/services/player-instances/history.ts
+++ b/src/services/player-instances/history.ts
@@ -42,8 +42,8 @@ export const getActivities = async (
                     season_id AS "season",
                     duration AS "duration",
                     platform_type AS "platformType",
-                    CASE WHEN av.is_world_first THEN date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') ELSE false END AS "isDayOne",
-                    CASE WHEN av.is_world_first THEN date_completed < COALESCE(contest_end, TIMESTAMP 'epoch') ELSE false END AS "isContest",
+                    CASE WHEN av.is_contest_eligible THEN date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') ELSE false END AS "isDayOne",
+                    CASE WHEN av.is_contest_eligible THEN date_completed < COALESCE(contest_end, TIMESTAMP 'epoch') ELSE false END AS "isContest",
                     date_completed < COALESCE(week_one_end, TIMESTAMP 'epoch') AS "isWeekOne",
                     bi.instance_id IS NOT NULL AS "isBlacklisted",
                     JSONB_BUILD_OBJECT(

--- a/src/services/player-instances/instances.ts
+++ b/src/services/player-instances/instances.ts
@@ -134,8 +134,8 @@ export async function getInstances({
             season_id AS "season",
             duration AS "duration",
             platform_type AS "platformType",
-            CASE WHEN av.is_world_first THEN date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') ELSE false END AS "isDayOne",
-            CASE WHEN av.is_world_first THEN date_completed < COALESCE(contest_end, TIMESTAMP 'epoch') ELSE false END AS "isContest",
+            CASE WHEN av.is_contest_eligible THEN date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') ELSE false END AS "isDayOne",
+            CASE WHEN av.is_contest_eligible THEN date_completed < COALESCE(contest_end, TIMESTAMP 'epoch') ELSE false END AS "isContest",
             date_completed < COALESCE(week_one_end, TIMESTAMP 'epoch') AS "isWeekOne",
             b.instance_id IS NOT NULL AS "isBlacklisted",
             "_lateral".players AS "players"

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -57,8 +57,8 @@ export const getPlayerActivityStats = async (membershipId: bigint | string) => {
                             'season', fastest.season_id,
                             'duration', fastest.duration,
                             'platformType', fastest.platform_type,
-                            'isDayOne', CASE WHEN av.is_world_first THEN date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') ELSE false END,
-                            'isContest', CASE WHEN av.is_world_first THEN date_completed < COALESCE(contest_end, TIMESTAMP 'epoch') ELSE false END,
+                            'isDayOne', CASE WHEN av.is_contest_eligible THEN date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') ELSE false END,
+                            'isContest', CASE WHEN av.is_contest_eligible THEN date_completed < COALESCE(contest_end, TIMESTAMP 'epoch') ELSE false END,
                             'isWeekOne', date_completed < COALESCE(week_one_end, TIMESTAMP 'epoch'),
                             'isBlacklisted', bi.instance_id IS NOT NULL
                         ) 


### PR DESCRIPTION
This pull request updates the logic for determining whether an activity instance qualifies as "Day One" or "Contest" eligible. The main change is to use the `is_contest_eligible` flag instead of `is_world_first` for these determinations, ensuring more accurate classification of activity instances. Additionally, new tests have been added to verify the updated contest eligibility logic.

**Contest and Day One eligibility logic update:**

* Updated SQL queries in `getInstance`, `getInstances`, `getActivities`, and `getPlayerActivityStats` to use `av.is_contest_eligible` instead of `av.is_world_first` for calculating `isDayOne` and `isContest` flags. This ensures that these flags correctly reflect contest eligibility rather than world first status. [[1]](diffhunk://#diff-c69526342d6c7200ac48ef58330195389d5f23c218b98814cde5fa042e1fc7a7L26-R27) [[2]](diffhunk://#diff-afc3e869bd091809a739946ed9cea9482468e9f00d29c11b73d731c6ccdfdee2L137-R138) [[3]](diffhunk://#diff-28d46673c9b1f7638d2e75642dfb43709d4b69661f894ffe4ab5b3f8972c9cb8L45-R46) [[4]](diffhunk://#diff-56fde53d4e5107906947fc7476ccd5da900c3a183a34c8137a17080f55416669L60-R61)

**Testing improvements:**

* Added new tests in `instance.test.ts` to verify contest and day one status for specific activities, including day one King's Fall and Leviathan instances.