### PR TITLE
feat(subscriptions): per-target filters on Discord webhook PUT

### DIFF
--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -1805,41 +1805,62 @@
             "minLength": 1,
             "maxLength": 80
           },
-          "filters": {
-            "type": "object",
-            "properties": {
-              "requireFresh": {
-                "type": "boolean"
-              },
-              "requireCompleted": {
-                "type": "boolean"
-              },
-              "raids": {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "minimum": 0,
-                  "exclusiveMinimum": true
-                }
-              }
-            }
-          },
           "targets": {
             "type": "object",
             "properties": {
-              "playerMembershipIds": {
+              "players": {
                 "type": "array",
                 "items": {
-                  "type": "string",
-                  "pattern": "^\\d+$"
+                  "type": "object",
+                  "properties": {
+                    "membershipId": {
+                      "type": "string",
+                      "pattern": "^\\d+$"
+                    },
+                    "requireFresh": {
+                      "type": "boolean"
+                    },
+                    "requireCompleted": {
+                      "type": "boolean"
+                    },
+                    "raids": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "exclusiveMinimum": true
+                      }
+                    }
+                  },
+                  "required": ["membershipId"]
                 },
                 "maxItems": 250
               },
-              "clanGroupIds": {
+              "clans": {
                 "type": "array",
                 "items": {
-                  "type": "string",
-                  "pattern": "^\\d+$"
+                  "type": "object",
+                  "properties": {
+                    "groupId": {
+                      "type": "string",
+                      "pattern": "^\\d+$"
+                    },
+                    "requireFresh": {
+                      "type": "boolean"
+                    },
+                    "requireCompleted": {
+                      "type": "boolean"
+                    },
+                    "raids": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "exclusiveMinimum": true
+                      }
+                    }
+                  },
+                  "required": ["groupId"]
                 },
                 "maxItems": 250
               }

--- a/src/schema/components/DiscordSubscriptionWebhook.ts
+++ b/src/schema/components/DiscordSubscriptionWebhook.ts
@@ -4,27 +4,34 @@ import { z } from "zod"
 
 const MAX_DISCORD_WEBHOOK_TARGETS = 250
 
+const zDiscordWebhookPlayerTarget = z.object({
+    membershipId: z.string().regex(/^\d+$/),
+    requireFresh: z.boolean().optional(),
+    requireCompleted: z.boolean().optional(),
+    raids: z.array(zNaturalNumber()).optional()
+})
+
+const zDiscordWebhookClanTarget = z.object({
+    groupId: z.string().regex(/^\d+$/),
+    requireFresh: z.boolean().optional(),
+    requireCompleted: z.boolean().optional(),
+    raids: z.array(zNaturalNumber()).optional()
+})
+
 export type DiscordWebhookBody = z.input<typeof zDiscordWebhookBody>
 export const zDiscordWebhookBody = registry.register(
     "DiscordWebhookBody",
     z
         .object({
             name: z.string().min(1).max(80).optional(),
-            filters: z
-                .object({
-                    requireFresh: z.boolean().optional(),
-                    requireCompleted: z.boolean().optional(),
-                    raids: z.array(zNaturalNumber()).optional()
-                })
-                .optional(),
             targets: z
                 .object({
-                    playerMembershipIds: z
-                        .array(z.string().regex(/^\d+$/))
+                    players: z
+                        .array(zDiscordWebhookPlayerTarget)
                         .max(MAX_DISCORD_WEBHOOK_TARGETS)
                         .optional(),
-                    clanGroupIds: z
-                        .array(z.string().regex(/^\d+$/))
+                    clans: z
+                        .array(zDiscordWebhookClanTarget)
                         .max(MAX_DISCORD_WEBHOOK_TARGETS)
                         .optional()
                 })

--- a/src/services/subscriptions/discord-webhooks.integration.test.ts
+++ b/src/services/subscriptions/discord-webhooks.integration.test.ts
@@ -18,6 +18,7 @@ describe("discord webhook subscriptions service (postgres integration)", () => {
     const guildIdA = "999888777666555002"
     const guildIdB = "999888777666555003"
     const membershipId = "4611686019000990990"
+    const membershipIdB = "4611686019000990991"
 
     let webhookSeq = 0
     const nextWebhookId = () => `wh_int_${Date.now()}_${webhookSeq++}`
@@ -64,12 +65,12 @@ describe("discord webhook subscriptions service (postgres integration)", () => {
         await deleteFixtureRows()
     })
 
-    test("updateDiscordWebhook deactivates all player rules when targets.playerMembershipIds is empty", async () => {
+    test("updateDiscordWebhook deactivates all player rules when targets.players is empty", async () => {
         await seedActiveDestination()
 
         await updateDiscordWebhook(channelId, {
             guildId: guildIdA,
-            targets: { playerMembershipIds: [] }
+            targets: { players: [] }
         })
 
         const row = await fixtureDb.query<{ n: string }>(
@@ -82,13 +83,20 @@ describe("discord webhook subscriptions service (postgres integration)", () => {
         expect(row.rows[0].n).toBe("0")
     })
 
-    test("updateDiscordWebhook persists guild_id and rule updates touch updated_at when column exists", async () => {
+    test("updateDiscordWebhook persists guild_id and per-player rule filters", async () => {
         await seedActiveDestination()
 
         await updateDiscordWebhook(channelId, {
             guildId: guildIdB,
-            filters: { requireFresh: true, requireCompleted: true },
-            targets: { playerMembershipIds: [membershipId] }
+            targets: {
+                players: [
+                    {
+                        membershipId,
+                        requireFresh: true,
+                        requireCompleted: true
+                    }
+                ]
+            }
         })
 
         const cfg = await fixtureDb.query<{ guild_id: string }>(
@@ -114,6 +122,34 @@ describe("discord webhook subscriptions service (postgres integration)", () => {
         expect(rule.rows[0].updated_at).not.toBeNull()
     })
 
+    test("updateDiscordWebhook applies different filters per player in one request", async () => {
+        await seedActiveDestination()
+
+        await updateDiscordWebhook(channelId, {
+            guildId: guildIdA,
+            targets: {
+                players: [
+                    { membershipId, requireFresh: false, requireCompleted: false },
+                    { membershipId: membershipIdB, requireFresh: true, requireCompleted: false }
+                ]
+            }
+        })
+
+        const rows = await fixtureDb.query<{ membership_id: string; require_fresh: boolean }>(
+            `SELECT membership_id::text AS membership_id, require_fresh
+             FROM subscriptions.rule r
+             INNER JOIN subscriptions.discord_destination_config c ON c.destination_id = r.destination_id
+             WHERE c.channel_id = $1 AND r.scope = 'player' AND r.is_active
+             ORDER BY membership_id`,
+            [channelId]
+        )
+        expect(rows.rows).toHaveLength(2)
+        const a = rows.rows.find(r => r.membership_id === membershipId)
+        const b = rows.rows.find(r => r.membership_id === membershipIdB)
+        expect(a?.require_fresh).toBe(false)
+        expect(b?.require_fresh).toBe(true)
+    })
+
     test("getDiscordWebhookStatus returns active player rules for seeded destination", async () => {
         await seedActiveDestination()
 
@@ -130,8 +166,9 @@ describe("discord webhook subscriptions service (postgres integration)", () => {
 
         await updateDiscordWebhook(channelId, {
             guildId: guildIdA,
-            filters: { raids: [9] },
-            targets: { playerMembershipIds: [membershipId] }
+            targets: {
+                players: [{ membershipId, raids: [9] }]
+            }
         })
 
         const rule = await fixtureDb.query<{ activity_raid_bitmap: string }>(
@@ -158,7 +195,6 @@ describe("discord webhook subscriptions service (postgres integration)", () => {
         const out = await upsertDiscordWebhook({
             guildId: guildIdB,
             channelId,
-            filters: { requireFresh: false, requireCompleted: false },
             targets: {}
         })
 

--- a/src/services/subscriptions/discord-webhooks.test.ts
+++ b/src/services/subscriptions/discord-webhooks.test.ts
@@ -75,9 +75,7 @@ describe("discord webhook subscriptions service", () => {
         queueTransaction([{ destinationId: "42" }, { id: "42" }], [[]])
 
         const result = await updateDiscordWebhook("channel_x", {
-            guildId: "guild_x",
-            filters: { requireFresh: true, requireCompleted: false },
-            targets: {}
+            guildId: "guild_x"
         })
 
         expect(result).toEqual({
@@ -103,9 +101,7 @@ describe("discord webhook subscriptions service", () => {
 
         const result = await upsertDiscordWebhook({
             guildId: "guild_1",
-            channelId: "123456789",
-            filters: {},
-            targets: {}
+            channelId: "123456789"
         })
 
         expect(result).toEqual({
@@ -134,9 +130,7 @@ describe("discord webhook subscriptions service", () => {
 
         const result = await upsertDiscordWebhook({
             guildId: "guild_2",
-            channelId: "channel_2",
-            filters: {},
-            targets: {}
+            channelId: "channel_2"
         })
 
         expect(result.activated).toBe(true)
@@ -158,10 +152,9 @@ describe("discord webhook subscriptions service", () => {
         const result = await upsertDiscordWebhook({
             guildId: "guild_1",
             channelId: "123456789",
-            filters: {},
             targets: {
-                playerMembershipIds: [],
-                clanGroupIds: []
+                players: [],
+                clans: []
             }
         })
 
@@ -335,9 +328,7 @@ describe("discord webhook subscriptions service", () => {
             registerDiscordWebhook({
                 guildId: "g",
                 channelId: "c",
-                name: "Test",
-                filters: {},
-                targets: {}
+                name: "Test"
             })
         ).rejects.toThrow("DISCORD_BOT_TOKEN")
     })
@@ -354,9 +345,7 @@ describe("discord webhook subscriptions service", () => {
         return expect(
             registerDiscordWebhook({
                 guildId: "g",
-                channelId: "c",
-                filters: {},
-                targets: {}
+                channelId: "c"
             })
         ).rejects.toThrow("Discord webhook create failed with status 429")
     })
@@ -387,9 +376,7 @@ describe("discord webhook subscriptions service", () => {
         try {
             await registerDiscordWebhook({
                 guildId: "g",
-                channelId: "c",
-                filters: {},
-                targets: {}
+                channelId: "c"
             })
             expect.unreachable("registerDiscordWebhook should have thrown")
         } catch (error: unknown) {
@@ -419,9 +406,7 @@ describe("discord webhook subscriptions service", () => {
         try {
             await registerDiscordWebhook({
                 guildId: "g",
-                channelId: "c",
-                filters: {},
-                targets: {}
+                channelId: "c"
             })
             expect.unreachable("registerDiscordWebhook should have thrown")
         } catch (error: unknown) {
@@ -443,9 +428,7 @@ describe("discord webhook subscriptions service", () => {
 
         const result = await upsertDiscordWebhook({
             guildId: "guild_u",
-            channelId: "chan_u",
-            filters: {},
-            targets: {}
+            channelId: "chan_u"
         })
 
         expect(result.created).toBe(true)
@@ -481,9 +464,7 @@ describe("discord webhook subscriptions service", () => {
 
         const result = await registerDiscordWebhook({
             guildId: "guild_r",
-            channelId: "chan_r",
-            filters: {},
-            targets: {}
+            channelId: "chan_r"
         })
 
         expect(requests.map(r => r.method)).toEqual(["DELETE", "POST"])
@@ -507,9 +488,7 @@ describe("discord webhook subscriptions service", () => {
         const result = await registerDiscordWebhook({
             guildId: "guild_reg",
             channelId: "chan_reg",
-            name: "  CustomName  ",
-            filters: { requireFresh: true, requireCompleted: false },
-            targets: {}
+            name: "  CustomName  "
         })
 
         expect(result).toEqual({

--- a/src/services/subscriptions/discord-webhooks.ts
+++ b/src/services/subscriptions/discord-webhooks.ts
@@ -209,6 +209,30 @@ const resolveActivityRaidBitmap = async (raidIds?: number[]): Promise<number> =>
     return rows.reduce((bitmap, row) => bitmap + subscriptionRaidBitForActivityID(row.id), 0)
 }
 
+/** Dedupes identical raid lists across many targets in one PUT (one DB round-trip per unique list). */
+type RaidBitmapResolutionCache = Map<string, Promise<number>>
+
+const RAID_BITMAP_CACHE_EMPTY = "__empty__"
+
+const raidBitmapCacheKey = (raidIds?: number[]): string => {
+    if (!raidIds || raidIds.length === 0) return RAID_BITMAP_CACHE_EMPTY
+    return [...new Set(raidIds)].sort((a, b) => a - b).join(",")
+}
+
+const resolveActivityRaidBitmapCached = async (
+    raidIds: number[] | undefined,
+    cache: RaidBitmapResolutionCache
+): Promise<number> => {
+    const key = raidBitmapCacheKey(raidIds)
+    if (key === RAID_BITMAP_CACHE_EMPTY) return 0
+    let pending = cache.get(key)
+    if (!pending) {
+        pending = resolveActivityRaidBitmap(raidIds)
+        cache.set(key, pending)
+    }
+    return pending
+}
+
 const dedupePlayerTargets = (
     players: DiscordWebhookPlayerTargetInput[]
 ): DiscordWebhookPlayerTargetInput[] => {
@@ -234,7 +258,8 @@ const dedupeClanTargets = (
 }
 
 const resolvePlayerRuleRows = async (
-    players: DiscordWebhookPlayerTargetInput[] | undefined
+    players: DiscordWebhookPlayerTargetInput[] | undefined,
+    raidBitmapCache: RaidBitmapResolutionCache
 ): Promise<ResolvedPlayerRuleRow[] | undefined> => {
     if (players === undefined) return undefined
     const deduped = dedupePlayerTargets(players)
@@ -244,14 +269,15 @@ const resolvePlayerRuleRows = async (
             membershipId: p.membershipId,
             requireFresh: p.requireFresh ?? false,
             requireCompleted: p.requireCompleted ?? false,
-            activityRaidBitmap: await resolveActivityRaidBitmap(p.raids)
+            activityRaidBitmap: await resolveActivityRaidBitmapCached(p.raids, raidBitmapCache)
         })
     }
     return out
 }
 
 const resolveClanRuleRows = async (
-    clans: DiscordWebhookClanTargetInput[] | undefined
+    clans: DiscordWebhookClanTargetInput[] | undefined,
+    raidBitmapCache: RaidBitmapResolutionCache
 ): Promise<ResolvedClanRuleRow[] | undefined> => {
     if (clans === undefined) return undefined
     const deduped = dedupeClanTargets(clans)
@@ -261,7 +287,7 @@ const resolveClanRuleRows = async (
             groupId: c.groupId,
             requireFresh: c.requireFresh ?? false,
             requireCompleted: c.requireCompleted ?? false,
-            activityRaidBitmap: await resolveActivityRaidBitmap(c.raids)
+            activityRaidBitmap: await resolveActivityRaidBitmapCached(c.raids, raidBitmapCache)
         })
     }
     return out
@@ -518,8 +544,9 @@ export async function registerDiscordWebhook(
             name: input.name
         })
         const webhookUrl = validateDiscordWebhookUrl(createdWebhook.url)
-        const players = await resolvePlayerRuleRows(input.targets?.players)
-        const clans = await resolveClanRuleRows(input.targets?.clans)
+        const raidBitmapCache: RaidBitmapResolutionCache = new Map()
+        const players = await resolvePlayerRuleRows(input.targets?.players, raidBitmapCache)
+        const clans = await resolveClanRuleRows(input.targets?.clans, raidBitmapCache)
 
         const { created, activated, rules } = await pgAdmin.transaction(async tx => {
             const webhook = createdWebhook!
@@ -629,8 +656,9 @@ export async function updateDiscordWebhook(
         playerTargets: input.targets?.players?.length ?? 0,
         clanTargets: input.targets?.clans?.length ?? 0
     })
-    const players = await resolvePlayerRuleRows(input.targets?.players)
-    const clans = await resolveClanRuleRows(input.targets?.clans)
+    const raidBitmapCache: RaidBitmapResolutionCache = new Map()
+    const players = await resolvePlayerRuleRows(input.targets?.players, raidBitmapCache)
+    const clans = await resolveClanRuleRows(input.targets?.clans, raidBitmapCache)
 
     const rules = await pgAdmin.transaction(async tx =>
         updateDiscordWebhookInDb(tx, channelId, input, { players, clans })
@@ -692,8 +720,9 @@ export async function upsertDiscordWebhook(
         }
     }
 
-    const players = await resolvePlayerRuleRows(input.targets?.players)
-    const clans = await resolveClanRuleRows(input.targets?.clans)
+    const raidBitmapCache: RaidBitmapResolutionCache = new Map()
+    const players = await resolvePlayerRuleRows(input.targets?.players, raidBitmapCache)
+    const clans = await resolveClanRuleRows(input.targets?.clans, raidBitmapCache)
 
     const { rules, activated } = await pgAdmin.transaction(async tx => {
         let activatedInner = false

--- a/src/services/subscriptions/discord-webhooks.ts
+++ b/src/services/subscriptions/discord-webhooks.ts
@@ -3,18 +3,27 @@ import { Logger } from "@/lib/utils/logging"
 
 const logger = new Logger("DISCORD_SUBSCRIPTIONS_SERVICE")
 
+export type DiscordWebhookPlayerTargetInput = {
+    membershipId: string
+    requireFresh?: boolean
+    requireCompleted?: boolean
+    raids?: number[]
+}
+
+export type DiscordWebhookClanTargetInput = {
+    groupId: string
+    requireFresh?: boolean
+    requireCompleted?: boolean
+    raids?: number[]
+}
+
 export type RegisterDiscordWebhookInput = {
     guildId: string
     channelId: string
     name?: string
-    filters?: {
-        requireFresh?: boolean
-        requireCompleted?: boolean
-        raids?: number[]
-    }
     targets?: {
-        playerMembershipIds?: string[]
-        clanGroupIds?: string[]
+        players?: DiscordWebhookPlayerTargetInput[]
+        clans?: DiscordWebhookClanTargetInput[]
     }
 }
 
@@ -39,14 +48,9 @@ export type RegisterDiscordWebhookResult = {
 
 export type UpdateDiscordWebhookInput = {
     guildId: string
-    filters?: {
-        requireFresh?: boolean
-        requireCompleted?: boolean
-        raids?: number[]
-    }
     targets?: {
-        playerMembershipIds?: string[]
-        clanGroupIds?: string[]
+        players?: DiscordWebhookPlayerTargetInput[]
+        clans?: DiscordWebhookClanTargetInput[]
     }
 }
 
@@ -153,8 +157,20 @@ const validateDiscordWebhookUrl = (raw: string) => {
 }
 
 const toBigIntString = (value: string) => BigInt(value).toString()
-const normalizeTargetIds = (values?: string[]) =>
-    values === undefined ? undefined : [...new Set(values.map(toBigIntString))]
+
+type ResolvedPlayerRuleRow = {
+    membershipId: string
+    requireFresh: boolean
+    requireCompleted: boolean
+    activityRaidBitmap: number
+}
+
+type ResolvedClanRuleRow = {
+    groupId: string
+    requireFresh: boolean
+    requireCompleted: boolean
+    activityRaidBitmap: number
+}
 
 const subscriptionRaidBitForActivityID = (activityId: number): number => {
     if (activityId === 101) return 2 ** 33
@@ -193,6 +209,58 @@ const resolveActivityRaidBitmap = async (raidIds?: number[]): Promise<number> =>
     return rows.reduce((bitmap, row) => bitmap + subscriptionRaidBitForActivityID(row.id), 0)
 }
 
+const dedupePlayerTargets = (players: DiscordWebhookPlayerTargetInput[]): DiscordWebhookPlayerTargetInput[] => {
+    const map = new Map<string, DiscordWebhookPlayerTargetInput>()
+    for (const raw of players) {
+        const id = toBigIntString(String(raw.membershipId).trim())
+        map.set(id, { ...raw, membershipId: id })
+    }
+    return [...map.values()].sort((a, b) => (BigInt(a.membershipId) < BigInt(b.membershipId) ? -1 : 1))
+}
+
+const dedupeClanTargets = (clans: DiscordWebhookClanTargetInput[]): DiscordWebhookClanTargetInput[] => {
+    const map = new Map<string, DiscordWebhookClanTargetInput>()
+    for (const raw of clans) {
+        const id = toBigIntString(String(raw.groupId).trim())
+        map.set(id, { ...raw, groupId: id })
+    }
+    return [...map.values()].sort((a, b) => (BigInt(a.groupId) < BigInt(b.groupId) ? -1 : 1))
+}
+
+const resolvePlayerRuleRows = async (
+    players: DiscordWebhookPlayerTargetInput[] | undefined
+): Promise<ResolvedPlayerRuleRow[] | undefined> => {
+    if (players === undefined) return undefined
+    const deduped = dedupePlayerTargets(players)
+    const out: ResolvedPlayerRuleRow[] = []
+    for (const p of deduped) {
+        out.push({
+            membershipId: p.membershipId,
+            requireFresh: p.requireFresh ?? false,
+            requireCompleted: p.requireCompleted ?? false,
+            activityRaidBitmap: await resolveActivityRaidBitmap(p.raids)
+        })
+    }
+    return out
+}
+
+const resolveClanRuleRows = async (
+    clans: DiscordWebhookClanTargetInput[] | undefined
+): Promise<ResolvedClanRuleRow[] | undefined> => {
+    if (clans === undefined) return undefined
+    const deduped = dedupeClanTargets(clans)
+    const out: ResolvedClanRuleRow[] = []
+    for (const c of deduped) {
+        out.push({
+            groupId: c.groupId,
+            requireFresh: c.requireFresh ?? false,
+            requireCompleted: c.requireCompleted ?? false,
+            activityRaidBitmap: await resolveActivityRaidBitmap(c.raids)
+        })
+    }
+    return out
+}
+
 /** Prior Discord webhook id for this channel, if any (used before replacing on re-register). */
 async function getExistingDiscordWebhookIdForChannel(channelId: string): Promise<string | null> {
     const row = await pgAdmin.queryRow<{ webhookId: string | null }>(
@@ -227,22 +295,15 @@ async function upsertDiscordRules(
     db: Pick<typeof pgAdmin, "queryRow" | "queryRows">,
     destinationId: string,
     options: {
-        requireFresh: boolean
-        requireCompleted: boolean
-        activityRaidBitmap: number
-        playerMembershipIds?: string[]
-        clanGroupIds?: string[]
+        players?: ResolvedPlayerRuleRow[]
+        clans?: ResolvedClanRuleRow[]
     }
 ) {
-    const {
-        requireFresh,
-        requireCompleted,
-        activityRaidBitmap,
-        playerMembershipIds,
-        clanGroupIds
-    } = options
+    const { players, clans } = options
     const playerInsertResults: { inserted: number; updated: number }[] = []
-    for (const membershipId of playerMembershipIds ?? []) {
+
+    for (const row of players ?? []) {
+        const { membershipId, requireFresh, requireCompleted, activityRaidBitmap } = row
         const insertedRows = await db.queryRows<{ rowCount: number }>(
             `INSERT INTO subscriptions.rule (
                 destination_id,
@@ -300,7 +361,8 @@ async function upsertDiscordRules(
         playerInsertResults.push({ inserted: 0, updated: 1 })
     }
 
-    if (playerMembershipIds !== undefined) {
+    if (players !== undefined) {
+        const playerIds = players.map(p => p.membershipId)
         await db.queryRows(
             `UPDATE subscriptions.rule
              SET is_active = false,
@@ -312,12 +374,13 @@ async function upsertDiscordRules(
                     array_length($2::bigint[], 1) IS NULL
                     OR membership_id <> ALL($2::bigint[])
                )`,
-            { params: [destinationId, playerMembershipIds] }
+            { params: [destinationId, playerIds] }
         )
     }
 
     const clanInsertResults: { inserted: number; updated: number }[] = []
-    for (const groupId of clanGroupIds ?? []) {
+    for (const row of clans ?? []) {
+        const { groupId, requireFresh, requireCompleted, activityRaidBitmap } = row
         const insertedRows = await db.queryRows<{ rowCount: number }>(
             `INSERT INTO subscriptions.rule (
                 destination_id,
@@ -363,7 +426,8 @@ async function upsertDiscordRules(
         clanInsertResults.push({ inserted: 0, updated: 1 })
     }
 
-    if (clanGroupIds !== undefined) {
+    if (clans !== undefined) {
+        const groupIds = clans.map(c => c.groupId)
         await db.queryRows(
             `UPDATE subscriptions.rule
              SET is_active = false,
@@ -375,7 +439,7 @@ async function upsertDiscordRules(
                     array_length($2::bigint[], 1) IS NULL
                     OR group_id <> ALL($2::bigint[])
                )`,
-            { params: [destinationId, clanGroupIds] }
+            { params: [destinationId, groupIds] }
         )
     }
 
@@ -398,20 +462,11 @@ async function updateDiscordWebhookInDb(
     channelId: string,
     input: UpdateDiscordWebhookInput,
     normalized: {
-        requireFresh: boolean
-        requireCompleted: boolean
-        activityRaidBitmap: number
-        playerMembershipIds?: string[]
-        clanGroupIds?: string[]
+        players?: ResolvedPlayerRuleRow[]
+        clans?: ResolvedClanRuleRow[]
     }
 ): Promise<RegisterDiscordWebhookResult["rules"]> {
-    const {
-        requireFresh,
-        requireCompleted,
-        activityRaidBitmap,
-        playerMembershipIds,
-        clanGroupIds
-    } = normalized
+    const { players, clans } = normalized
     const destinationId = await getDiscordDestinationIdByChannelId(tx, channelId)
     const existing = await tx.queryRow<{ id: string }>(
         `SELECT id::text AS "id"
@@ -432,13 +487,7 @@ async function updateDiscordWebhookInDb(
         { params: [destinationId, input.guildId] }
     )
 
-    return upsertDiscordRules(tx, destinationId, {
-        requireFresh,
-        requireCompleted,
-        activityRaidBitmap,
-        playerMembershipIds,
-        clanGroupIds
-    })
+    return upsertDiscordRules(tx, destinationId, { players, clans })
 }
 
 export async function registerDiscordWebhook(
@@ -448,8 +497,8 @@ export async function registerDiscordWebhook(
         guildId: input.guildId,
         channelId: input.channelId,
         hasName: Boolean(input.name),
-        playerTargets: input.targets?.playerMembershipIds?.length ?? 0,
-        clanTargets: input.targets?.clanGroupIds?.length ?? 0
+        playerTargets: input.targets?.players?.length ?? 0,
+        clanTargets: input.targets?.clans?.length ?? 0
     })
     let createdWebhook: { id: string; token: string; url: string } | null = null
     try {
@@ -463,11 +512,8 @@ export async function registerDiscordWebhook(
             name: input.name
         })
         const webhookUrl = validateDiscordWebhookUrl(createdWebhook.url)
-        const requireFresh = input.filters?.requireFresh ?? false
-        const requireCompleted = input.filters?.requireCompleted ?? false
-        const activityRaidBitmap = await resolveActivityRaidBitmap(input.filters?.raids)
-        const playerMembershipIds = normalizeTargetIds(input.targets?.playerMembershipIds)
-        const clanGroupIds = normalizeTargetIds(input.targets?.clanGroupIds)
+        const players = await resolvePlayerRuleRows(input.targets?.players)
+        const clans = await resolveClanRuleRows(input.targets?.clans)
 
         const { created, activated, rules } = await pgAdmin.transaction(async tx => {
             const webhook = createdWebhook!
@@ -531,13 +577,7 @@ export async function registerDiscordWebhook(
                 }
             )
 
-            const rules = await upsertDiscordRules(tx, destinationId, {
-                requireFresh,
-                requireCompleted,
-                activityRaidBitmap,
-                playerMembershipIds,
-                clanGroupIds
-            })
+            const rules = await upsertDiscordRules(tx, destinationId, { players, clans })
 
             return { created, activated, rules }
         })
@@ -580,26 +620,14 @@ export async function updateDiscordWebhook(
     logger.info("DISCORD_WEBHOOK_UPDATE_REQUESTED", {
         guildId: input.guildId,
         channelId,
-        playerTargets: input.targets?.playerMembershipIds?.length ?? 0,
-        clanTargets: input.targets?.clanGroupIds?.length ?? 0,
-        requireFresh: input.filters?.requireFresh ?? false,
-        requireCompleted: input.filters?.requireCompleted ?? false,
-        raidFiltersCount: input.filters?.raids?.length ?? 0
+        playerTargets: input.targets?.players?.length ?? 0,
+        clanTargets: input.targets?.clans?.length ?? 0
     })
-    const requireFresh = input.filters?.requireFresh ?? false
-    const requireCompleted = input.filters?.requireCompleted ?? false
-    const activityRaidBitmap = await resolveActivityRaidBitmap(input.filters?.raids)
-    const playerMembershipIds = normalizeTargetIds(input.targets?.playerMembershipIds)
-    const clanGroupIds = normalizeTargetIds(input.targets?.clanGroupIds)
+    const players = await resolvePlayerRuleRows(input.targets?.players)
+    const clans = await resolveClanRuleRows(input.targets?.clans)
 
     const rules = await pgAdmin.transaction(async tx =>
-        updateDiscordWebhookInDb(tx, channelId, input, {
-            requireFresh,
-            requireCompleted,
-            activityRaidBitmap,
-            playerMembershipIds,
-            clanGroupIds
-        })
+        updateDiscordWebhookInDb(tx, channelId, input, { players, clans })
     )
 
     logger.info("DISCORD_WEBHOOK_UPDATE_COMPLETED", {
@@ -658,11 +686,8 @@ export async function upsertDiscordWebhook(
         }
     }
 
-    const requireFresh = input.filters?.requireFresh ?? false
-    const requireCompleted = input.filters?.requireCompleted ?? false
-    const activityRaidBitmap = await resolveActivityRaidBitmap(input.filters?.raids)
-    const playerMembershipIds = normalizeTargetIds(input.targets?.playerMembershipIds)
-    const clanGroupIds = normalizeTargetIds(input.targets?.clanGroupIds)
+    const players = await resolvePlayerRuleRows(input.targets?.players)
+    const clans = await resolveClanRuleRows(input.targets?.clans)
 
     const { rules, activated } = await pgAdmin.transaction(async tx => {
         let activatedInner = false
@@ -683,22 +708,10 @@ export async function upsertDiscordWebhook(
             })
         }
 
-        const rulesInner = await updateDiscordWebhookInDb(
-            tx,
-            input.channelId,
-            {
-                guildId: input.guildId,
-                filters: input.filters,
-                targets: input.targets
-            },
-            {
-                requireFresh,
-                requireCompleted,
-                activityRaidBitmap,
-                playerMembershipIds,
-                clanGroupIds
-            }
-        )
+        const rulesInner = await updateDiscordWebhookInDb(tx, input.channelId, input, {
+            players,
+            clans
+        })
 
         return { rules: rulesInner, activated: activatedInner }
     })

--- a/src/services/subscriptions/discord-webhooks.ts
+++ b/src/services/subscriptions/discord-webhooks.ts
@@ -209,16 +209,22 @@ const resolveActivityRaidBitmap = async (raidIds?: number[]): Promise<number> =>
     return rows.reduce((bitmap, row) => bitmap + subscriptionRaidBitForActivityID(row.id), 0)
 }
 
-const dedupePlayerTargets = (players: DiscordWebhookPlayerTargetInput[]): DiscordWebhookPlayerTargetInput[] => {
+const dedupePlayerTargets = (
+    players: DiscordWebhookPlayerTargetInput[]
+): DiscordWebhookPlayerTargetInput[] => {
     const map = new Map<string, DiscordWebhookPlayerTargetInput>()
     for (const raw of players) {
         const id = toBigIntString(String(raw.membershipId).trim())
         map.set(id, { ...raw, membershipId: id })
     }
-    return [...map.values()].sort((a, b) => (BigInt(a.membershipId) < BigInt(b.membershipId) ? -1 : 1))
+    return [...map.values()].sort((a, b) =>
+        BigInt(a.membershipId) < BigInt(b.membershipId) ? -1 : 1
+    )
 }
 
-const dedupeClanTargets = (clans: DiscordWebhookClanTargetInput[]): DiscordWebhookClanTargetInput[] => {
+const dedupeClanTargets = (
+    clans: DiscordWebhookClanTargetInput[]
+): DiscordWebhookClanTargetInput[] => {
     const map = new Map<string, DiscordWebhookClanTargetInput>()
     for (const raw of clans) {
         const id = toBigIntString(String(raw.groupId).trim())


### PR DESCRIPTION
## Summary
Breaking change for `PUT /subscriptions/discord/webhooks/:channelId` (and OpenAPI): subscription rules are expressed **per target** instead of a shared `filters` object.

### Request body
- `targets.players`: array of `{ membershipId, requireFresh?, requireCompleted?, raids? }`
- `targets.clans`: array of `{ groupId, requireFresh?, requireCompleted?, raids? }`
- Removed: `filters`, `propagateFiltersToAllTargets`

### Behavior
- Each listed player/clan becomes one rule row; filters are stored on that row.
- Targets omitted from the PUT are removed from the subscription (same as before for empty arrays).

### Coordination
Deploy **API before** the Discord bot update that sends this body (see raidhub-discord PR).

Made with [Cursor](https://cursor.com)