### PR TITLE
fix(instance): compute isContest from contest version (v32) vs legacy window

### DIFF
--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -311,7 +311,7 @@
           },
           "isContest": {
             "type": "boolean",
-            "description": "If the instance was completed before the contest end date"
+            "description": "If this clear was contest mode: when the activity exposes version_id 32 (contest) on activity_version, true only for that version while still before contest_end; otherwise true when completed before contest_end (legacy raids)."
           },
           "isWeekOne": {
             "type": "boolean",

--- a/src/schema/components/Instance.ts
+++ b/src/schema/components/Instance.ts
@@ -39,7 +39,8 @@ export const zInstance = registry.register(
                 description: "If the instance was completed before the day one end date"
             }),
             isContest: z.boolean().openapi({
-                description: "If the instance was completed before the contest end date"
+                description:
+                    "If this clear was contest mode: when the activity exposes version_id 32 (contest) on activity_version, true only for that version while still before contest_end; otherwise true when completed before contest_end (legacy raids)."
             }),
             isWeekOne: z.boolean().openapi({
                 description: "If the instance was completed before the week one end date"

--- a/src/services/instance/instance.test.ts
+++ b/src/services/instance/instance.test.ts
@@ -209,3 +209,125 @@ describe("getLeaderboardEntryForInstance", () => {
         }
     })
 })
+
+/** Same timing window as public PGCR [16326292274](https://raidhub.io/pgcr/16326292274): Standard clear during Desert Perpetual contest. */
+const DP_PGCR_EXAMPLE_COMPLETED_AT = "2025-07-21T01:16:02.000Z"
+const INSTANCE_DP_STANDARD = "999000000801"
+const INSTANCE_DP_CONTEST = "999000000802"
+const INSTANCE_VOW_STANDARD = "999000000803"
+const PUBLIC_DP_PGCR_INSTANCE_ID = "16326292274"
+
+describe("getInstance isContest (Desert Perpetual / pgcr 16326292274)", () => {
+    let dpStandardHash: string | null = null
+    let dpContestHash: string | null = null
+    let vowStandardHash: string | null = null
+
+    beforeAll(async () => {
+        const [dpStd, dpCst, vowStd] = await Promise.all([
+            fixtureDb.query<{ h: string }>(
+                `SELECT hash::text AS h FROM definitions.activity_version WHERE activity_id = 15 AND version_id = 1 LIMIT 1`
+            ),
+            fixtureDb.query<{ h: string }>(
+                `SELECT hash::text AS h FROM definitions.activity_version WHERE activity_id = 15 AND version_id = 32 LIMIT 1`
+            ),
+            fixtureDb.query<{ h: string }>(
+                `SELECT hash::text AS h FROM definitions.activity_version WHERE activity_id = 10 AND version_id = 1 LIMIT 1`
+            )
+        ])
+        dpStandardHash = dpStd.rows[0]?.h ?? null
+        dpContestHash = dpCst.rows[0]?.h ?? null
+        vowStandardHash = vowStd.rows[0]?.h ?? null
+
+        if (!dpStandardHash || !dpContestHash) {
+            return
+        }
+
+        for (const id of [INSTANCE_DP_STANDARD, INSTANCE_DP_CONTEST, INSTANCE_VOW_STANDARD]) {
+            await fixtureDb.query(`DELETE FROM core.instance WHERE instance_id = $1::bigint`, [id])
+        }
+
+        await fixtureDb.query(
+            `INSERT INTO core.instance (
+                instance_id, hash, score, flawless, completed, fresh, player_count,
+                date_started, date_completed, duration, platform_type, is_whitelisted, skull_hashes
+            ) VALUES
+            ($1::bigint, $2::bigint, 0, false, true, true, 6, $5::timestamptz, $5::timestamptz, 732, 3, false, ARRAY[]::bigint[]),
+            ($3::bigint, $4::bigint, 0, false, true, true, 6, $5::timestamptz, $5::timestamptz, 732, 3, false, ARRAY[]::bigint[])`,
+            [
+                INSTANCE_DP_STANDARD,
+                dpStandardHash,
+                INSTANCE_DP_CONTEST,
+                dpContestHash,
+                DP_PGCR_EXAMPLE_COMPLETED_AT
+            ]
+        )
+
+        if (vowStandardHash) {
+            await fixtureDb.query(
+                `INSERT INTO core.instance (
+                    instance_id, hash, score, flawless, completed, fresh, player_count,
+                    date_started, date_completed, duration, platform_type, is_whitelisted, skull_hashes
+                ) VALUES (
+                    $1::bigint, $2::bigint, 0, false, true, true, 6,
+                    '2022-03-06T12:00:00Z'::timestamptz, '2022-03-06T12:30:00Z'::timestamptz, 1800, 3, false, ARRAY[]::bigint[]
+                )`,
+                [INSTANCE_VOW_STANDARD, vowStandardHash]
+            )
+        }
+    })
+
+    afterAll(async () => {
+        for (const id of [INSTANCE_DP_STANDARD, INSTANCE_DP_CONTEST, INSTANCE_VOW_STANDARD]) {
+            await fixtureDb.query(`DELETE FROM core.instance WHERE instance_id = $1::bigint`, [id])
+        }
+    })
+
+    test("Desert Perpetual Standard during contest window → isContest false (pgcr 16326292274 scenario)", async () => {
+        if (!dpStandardHash || !dpContestHash) {
+            throw new Error(
+                "Missing definitions.activity_version for Desert Perpetual (activity_id 15) versions 1 and 32 — run Services migrations + seeds."
+            )
+        }
+        const row = await getInstance(INSTANCE_DP_STANDARD)
+        expect(row).not.toBeNull()
+        expect(row!.activityId).toBe(15)
+        expect(row!.versionId).toBe(1)
+        expect(row!.isContest).toBe(false)
+    })
+
+    test("Desert Perpetual contest hash during contest window → isContest true", async () => {
+        if (!dpStandardHash || !dpContestHash) {
+            throw new Error(
+                "Missing definitions.activity_version for Desert Perpetual (activity_id 15) versions 1 and 32 — run Services migrations + seeds."
+            )
+        }
+        const row = await getInstance(INSTANCE_DP_CONTEST)
+        expect(row).not.toBeNull()
+        expect(row!.activityId).toBe(15)
+        expect(row!.versionId).toBe(32)
+        expect(row!.isContest).toBe(true)
+    })
+
+    test("legacy raid (no version 32 row): Standard before contest_end → isContest true", async () => {
+        if (!vowStandardHash) {
+            throw new Error(
+                "Missing definitions.activity_version for Vow (activity_id 10) version 1 — run Services migrations + seeds."
+            )
+        }
+        const row = await getInstance(INSTANCE_VOW_STANDARD)
+        expect(row).not.toBeNull()
+        expect(row!.activityId).toBe(10)
+        expect(row!.versionId).toBe(1)
+        expect(row!.isContest).toBe(true)
+    })
+
+    test("optional: public PGCR 16326292274 row when present in DB", async () => {
+        const row = await getInstance(PUBLIC_DP_PGCR_INSTANCE_ID)
+        if (row === null) {
+            return
+        }
+        expect(row.activityId).toBe(15)
+        expect(row.versionId).toBe(1)
+        expect(row.isContest).toBe(false)
+    })
+})

--- a/src/services/instance/instance.ts
+++ b/src/services/instance/instance.ts
@@ -29,12 +29,25 @@ export async function getInstance(instanceId: bigint | string): Promise<Instance
             duration::int AS "duration",
             platform_type AS "platformType",
             date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') AS "isDayOne",
-            date_completed < COALESCE(contest_end, TIMESTAMP 'epoch') AS "isContest",
+            (
+                CASE
+                    WHEN ig_cact.activity_id IS NOT NULL THEN (
+                        av.version_id = 32
+                        AND instance.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
+                    )
+                    ELSE instance.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
+                END
+            ) AS "isContest",
             date_completed < COALESCE(week_one_end, TIMESTAMP 'epoch') AS "isWeekOne",
             (b.instance_id IS NOT NULL AND NOT COALESCE(instance.is_whitelisted, false)) AS "isBlacklisted"
         FROM instance
         INNER JOIN activity_version av USING (hash)
         INNER JOIN activity_definition ON activity_definition.id = av.activity_id
+        LEFT JOIN (
+            SELECT DISTINCT avc.activity_id
+            FROM activity_version avc
+            WHERE avc.version_id = 32
+        ) ig_cact ON ig_cact.activity_id = activity_definition.id
         LEFT JOIN blacklist_instance b USING (instance_id)
         WHERE instance_id = $1::bigint
         LIMIT 1;`,

--- a/src/services/instance/instance.ts
+++ b/src/services/instance/instance.ts
@@ -13,22 +13,22 @@ import { PlayerInfo } from "@/schema/components/PlayerInfo"
 export async function getInstance(instanceId: bigint | string): Promise<Instance | null> {
     return await pgReader.queryRow<Instance>(
         `SELECT
-            instance_id AS "instanceId",
-            hash AS "hash",
-            activity_id::int AS "activityId",
-            version_id::int AS "versionId",
-            completed AS "completed",
-            player_count::int AS "playerCount",
-            score::int AS "score",
-            fresh AS "fresh",
-            flawless AS "flawless",
-            skull_hashes AS "skullHashes",
-            date_started AS "dateStarted",
-            date_completed AS "dateCompleted",
-            season_id::int AS "season",
-            duration::int AS "duration",
-            platform_type AS "platformType",
-            date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') AS "isDayOne",
+            instance.instance_id AS "instanceId",
+            instance.hash AS "hash",
+            av.activity_id::int AS "activityId",
+            av.version_id::int AS "versionId",
+            instance.completed AS "completed",
+            instance.player_count::int AS "playerCount",
+            instance.score::int AS "score",
+            instance.fresh AS "fresh",
+            instance.flawless AS "flawless",
+            instance.skull_hashes AS "skullHashes",
+            instance.date_started AS "dateStarted",
+            instance.date_completed AS "dateCompleted",
+            instance.season_id::int AS "season",
+            instance.duration::int AS "duration",
+            instance.platform_type AS "platformType",
+            instance.date_completed < COALESCE(activity_definition.day_one_end, TIMESTAMP 'epoch') AS "isDayOne",
             (
                 CASE
                     WHEN ig_cact.activity_id IS NOT NULL THEN (
@@ -38,7 +38,7 @@ export async function getInstance(instanceId: bigint | string): Promise<Instance
                     ELSE instance.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
                 END
             ) AS "isContest",
-            date_completed < COALESCE(week_one_end, TIMESTAMP 'epoch') AS "isWeekOne",
+            instance.date_completed < COALESCE(activity_definition.week_one_end, TIMESTAMP 'epoch') AS "isWeekOne",
             (b.instance_id IS NOT NULL AND NOT COALESCE(instance.is_whitelisted, false)) AS "isBlacklisted"
         FROM instance
         INNER JOIN activity_version av USING (hash)
@@ -49,7 +49,7 @@ export async function getInstance(instanceId: bigint | string): Promise<Instance
             WHERE avc.version_id = 32
         ) ig_cact ON ig_cact.activity_id = activity_definition.id
         LEFT JOIN blacklist_instance b USING (instance_id)
-        WHERE instance_id = $1::bigint
+        WHERE instance.instance_id = $1::bigint
         LIMIT 1;`,
         {
             params: [instanceId],

--- a/src/services/player-instances/history.ts
+++ b/src/services/player-instances/history.ts
@@ -53,7 +53,15 @@ export const getActivities = async (
                     duration::int AS "duration",
                     platform_type AS "platformType",
                     date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') AS "isDayOne",
-                    date_completed < COALESCE(contest_end, TIMESTAMP 'epoch') AS "isContest",
+                    (
+                        CASE
+                            WHEN ph_cact.activity_id IS NOT NULL THEN (
+                                av.version_id = 32
+                                AND instance.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
+                            )
+                            ELSE instance.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
+                        END
+                    ) AS "isContest",
                     date_completed < COALESCE(week_one_end, TIMESTAMP 'epoch') AS "isWeekOne",
                     (bi.instance_id IS NOT NULL AND NOT COALESCE(instance.is_whitelisted, false)) AS "isBlacklisted",
                     JSONB_BUILD_OBJECT(
@@ -67,6 +75,11 @@ export const getActivities = async (
                 LEFT JOIN blacklist_instance bi USING (instance_id)
                 INNER JOIN activity_version av USING (hash)
                 INNER JOIN activity_definition ON activity_definition.id = av.activity_id
+                LEFT JOIN (
+                    SELECT DISTINCT avc.activity_id
+                    FROM activity_version avc
+                    WHERE avc.version_id = 32
+                ) ph_cact ON ph_cact.activity_id = activity_definition.id
                 WHERE membership_id = $1::bigint
                 ${cursor ? `AND date_completed < $${++paramIndex}` : ""}
                 ${cutoff ? `AND date_completed > $${++paramIndex}` : ""}

--- a/src/services/player-instances/history.ts
+++ b/src/services/player-instances/history.ts
@@ -37,22 +37,22 @@ export const getActivities = async (
 
             return await pgReader.queryRows<InstanceForPlayer>(
                 `SELECT
-                    instance_id AS "instanceId",
-                    hash AS "hash",
-                    activity_id::int AS "activityId",
-                    version_id::int AS "versionId",
+                    instance.instance_id AS "instanceId",
+                    instance.hash AS "hash",
+                    av.activity_id::int AS "activityId",
+                    av.version_id::int AS "versionId",
                     instance.completed AS "completed",
-                    player_count::int AS "playerCount",
-                    score::int AS "score",
-                    fresh AS "fresh",
-                    flawless AS "flawless",
-                    skull_hashes AS "skullHashes",
-                    date_started AS "dateStarted",
-                    date_completed AS "dateCompleted",
-                    season_id::int AS "season",
-                    duration::int AS "duration",
-                    platform_type AS "platformType",
-                    date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') AS "isDayOne",
+                    instance.player_count::int AS "playerCount",
+                    instance.score::int AS "score",
+                    instance.fresh AS "fresh",
+                    instance.flawless AS "flawless",
+                    instance.skull_hashes AS "skullHashes",
+                    instance.date_started AS "dateStarted",
+                    instance.date_completed AS "dateCompleted",
+                    instance.season_id::int AS "season",
+                    instance.duration::int AS "duration",
+                    instance.platform_type AS "platformType",
+                    instance.date_completed < COALESCE(activity_definition.day_one_end, TIMESTAMP 'epoch') AS "isDayOne",
                     (
                         CASE
                             WHEN ph_cact.activity_id IS NOT NULL THEN (
@@ -62,7 +62,7 @@ export const getActivities = async (
                             ELSE instance.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
                         END
                     ) AS "isContest",
-                    date_completed < COALESCE(week_one_end, TIMESTAMP 'epoch') AS "isWeekOne",
+                    instance.date_completed < COALESCE(activity_definition.week_one_end, TIMESTAMP 'epoch') AS "isWeekOne",
                     (bi.instance_id IS NOT NULL AND NOT COALESCE(instance.is_whitelisted, false)) AS "isBlacklisted",
                     JSONB_BUILD_OBJECT(
                         'completed', instance_player.completed,
@@ -81,9 +81,9 @@ export const getActivities = async (
                     WHERE avc.version_id = 32
                 ) ph_cact ON ph_cact.activity_id = activity_definition.id
                 WHERE membership_id = $1::bigint
-                ${cursor ? `AND date_completed < $${++paramIndex}` : ""}
-                ${cutoff ? `AND date_completed > $${++paramIndex}` : ""}
-                ORDER BY date_completed DESC
+                ${cursor ? `AND instance.date_completed < $${++paramIndex}` : ""}
+                ${cutoff ? `AND instance.date_completed > $${++paramIndex}` : ""}
+                ORDER BY instance.date_completed DESC
                 LIMIT $2;`,
                 // Note: the use of strictly less than is important because the cursor is the date of the last activity
                 // that was fetched. If we used less than or equal to, we would fetch the same activity twice.

--- a/src/services/player-instances/instances.ts
+++ b/src/services/player-instances/instances.ts
@@ -140,7 +140,15 @@ export async function getInstances({
             duration::int AS "duration",
             platform_type AS "platformType",
             date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') AS "isDayOne",
-            date_completed < COALESCE(contest_end, TIMESTAMP 'epoch') AS "isContest",
+            (
+                CASE
+                    WHEN pi2_cact.activity_id IS NOT NULL THEN (
+                        av.version_id = 32
+                        AND instance.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
+                    )
+                    ELSE instance.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
+                END
+            ) AS "isContest",
             date_completed < COALESCE(week_one_end, TIMESTAMP 'epoch') AS "isWeekOne",
             (b.instance_id IS NOT NULL AND NOT COALESCE(instance.is_whitelisted, false)) AS "isBlacklisted",
             "_lateral".players AS "players"
@@ -148,6 +156,11 @@ export async function getInstances({
         INNER JOIN instance USING (instance_id)
         INNER JOIN activity_version av USING (hash)
         INNER JOIN activity_definition ON activity_definition.id = av.activity_id
+        LEFT JOIN (
+            SELECT DISTINCT avc.activity_id
+            FROM activity_version avc
+            WHERE avc.version_id = 32
+        ) pi2_cact ON pi2_cact.activity_id = activity_definition.id
         LEFT JOIN blacklist_instance b USING (instance_id)
         LEFT JOIN LATERAL (
             SELECT

--- a/src/services/player-instances/instances.ts
+++ b/src/services/player-instances/instances.ts
@@ -59,63 +59,63 @@ export async function getInstances({
 
     if (activityId !== undefined) {
         params.push(activityId)
-        conditions.push(`activity_id = $${params.length}`)
+        conditions.push(`av.activity_id = $${params.length}`)
     }
     if (versionId !== undefined) {
         params.push(versionId)
-        conditions.push(`version_id = $${params.length}`)
+        conditions.push(`av.version_id = $${params.length}`)
     }
     if (completed !== undefined) {
         params.push(completed)
-        conditions.push(`completed = $${params.length}`)
+        conditions.push(`instance.completed = $${params.length}`)
     }
     if (fresh !== undefined) {
         params.push(fresh)
-        conditions.push(`fresh = $${params.length}`)
+        conditions.push(`instance.fresh = $${params.length}`)
     }
     if (flawless !== undefined) {
         params.push(flawless)
-        conditions.push(`flawless = $${params.length}`)
+        conditions.push(`instance.flawless = $${params.length}`)
     }
     if (playerCount !== undefined) {
         params.push(playerCount)
-        conditions.push(`player_count = $${params.length}`)
+        conditions.push(`instance.player_count = $${params.length}`)
     }
     if (minPlayerCount !== undefined) {
         params.push(minPlayerCount)
-        conditions.push(`player_count >= $${params.length}`)
+        conditions.push(`instance.player_count >= $${params.length}`)
     }
     if (maxPlayerCount !== undefined) {
         params.push(maxPlayerCount)
-        conditions.push(`player_count <= $${params.length}`)
+        conditions.push(`instance.player_count <= $${params.length}`)
     }
     if (minDurationSeconds !== undefined) {
         params.push(minDurationSeconds)
-        conditions.push(`duration >= $${params.length}`)
+        conditions.push(`instance.duration >= $${params.length}`)
     }
     if (maxDurationSeconds !== undefined) {
         params.push(maxDurationSeconds)
-        conditions.push(`duration <= $${params.length}`)
+        conditions.push(`instance.duration <= $${params.length}`)
     }
     if (season !== undefined) {
         params.push(season)
-        conditions.push(`season_id = $${params.length}`)
+        conditions.push(`instance.season_id = $${params.length}`)
     }
     if (minSeason !== undefined) {
         params.push(minSeason)
-        conditions.push(`season_id >= $${params.length}`)
+        conditions.push(`instance.season_id >= $${params.length}`)
     }
     if (maxSeason !== undefined) {
         params.push(maxSeason)
-        conditions.push(`season_id <= $${params.length}`)
+        conditions.push(`instance.season_id <= $${params.length}`)
     }
     if (minDate !== undefined) {
         params.push(minDate)
-        conditions.push(`date_started >= $${params.length}::timestamp`)
+        conditions.push(`instance.date_started >= $${params.length}::timestamp`)
     }
     if (maxDate !== undefined) {
         params.push(maxDate)
-        conditions.push(`date_completed <= $${params.length}::timestamp`)
+        conditions.push(`instance.date_completed <= $${params.length}::timestamp`)
     }
     conditions.push(`instance.player_count <= 25`)
 
@@ -124,22 +124,22 @@ export async function getInstances({
     return await pgReader.queryRows<InstanceWithPlayers>(
         `WITH _player_instances AS (${playerStmnts.join(" INTERSECT ")}) 
         SELECT
-            instance_id AS "instanceId",
-            hash AS "hash",
-            activity_id::int AS "activityId",
-            version_id::int AS "versionId",
-            completed AS "completed",
-            player_count::int AS "playerCount",
-            score::int AS "score",
-            fresh AS "fresh",
-            flawless AS "flawless",
-            skull_hashes AS "skullHashes",
-            date_started AS "dateStarted",
-            date_completed AS "dateCompleted",
-            season_id::int AS "season",
-            duration::int AS "duration",
-            platform_type AS "platformType",
-            date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') AS "isDayOne",
+            instance.instance_id AS "instanceId",
+            instance.hash AS "hash",
+            av.activity_id::int AS "activityId",
+            av.version_id::int AS "versionId",
+            instance.completed AS "completed",
+            instance.player_count::int AS "playerCount",
+            instance.score::int AS "score",
+            instance.fresh AS "fresh",
+            instance.flawless AS "flawless",
+            instance.skull_hashes AS "skullHashes",
+            instance.date_started AS "dateStarted",
+            instance.date_completed AS "dateCompleted",
+            instance.season_id::int AS "season",
+            instance.duration::int AS "duration",
+            instance.platform_type AS "platformType",
+            instance.date_completed < COALESCE(activity_definition.day_one_end, TIMESTAMP 'epoch') AS "isDayOne",
             (
                 CASE
                     WHEN pi2_cact.activity_id IS NOT NULL THEN (
@@ -149,7 +149,7 @@ export async function getInstances({
                     ELSE instance.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
                 END
             ) AS "isContest",
-            date_completed < COALESCE(week_one_end, TIMESTAMP 'epoch') AS "isWeekOne",
+            instance.date_completed < COALESCE(activity_definition.week_one_end, TIMESTAMP 'epoch') AS "isWeekOne",
             (b.instance_id IS NOT NULL AND NOT COALESCE(instance.is_whitelisted, false)) AS "isBlacklisted",
             "_lateral".players AS "players"
         FROM _player_instances
@@ -184,7 +184,7 @@ export async function getInstances({
             WHERE _player_instances.instance_id = _pi2.instance_id
         ) as "_lateral" ON true
         WHERE ${conditions.join(" AND ")}
-        ORDER BY date_completed DESC
+        ORDER BY instance.date_completed DESC
         LIMIT $${params.length}
         `,
         {

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -57,7 +57,15 @@ export const getPlayerActivityStats = async (membershipId: bigint | string) => {
                             'duration', fastest.duration::int,
                             'platformType', fastest.platform_type,
                             'isDayOne', date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch'),
-                            'isContest', date_completed < COALESCE(contest_end, TIMESTAMP 'epoch'),
+                            'isContest', (
+                                CASE
+                                    WHEN fa_cact.activity_id IS NOT NULL THEN (
+                                        av.version_id = 32
+                                        AND fastest.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
+                                    )
+                                    ELSE fastest.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
+                                END
+                            ),
                             'isWeekOne', date_completed < COALESCE(week_one_end, TIMESTAMP 'epoch'),
                             'isBlacklisted', bi.instance_id IS NOT NULL
                         )
@@ -69,6 +77,11 @@ export const getPlayerActivityStats = async (membershipId: bigint | string) => {
                 LEFT JOIN instance fastest ON player_stats.fastest_instance_id = fastest.instance_id
                 LEFT JOIN blacklist_instance bi ON player_stats.fastest_instance_id = bi.instance_id
                 LEFT JOIN activity_version av ON fastest.hash = av.hash
+                LEFT JOIN (
+                    SELECT DISTINCT av2.activity_id
+                    FROM activity_version av2
+                    WHERE av2.version_id = 32
+                ) fa_cact ON fa_cact.activity_id = activity_definition.id
                 ORDER BY activity_definition.id`,
                 {
                     params: [membershipId],
@@ -142,19 +155,35 @@ export const getWorldFirstEntries = async (membershipId: bigint | string) => {
                 `
                 SELECT DISTINCT ON (activity_definition.id)
                     activity_definition.id::int AS "activityId",
-                    rank::int,
-                    instance_id AS "instanceId",
-                    time_after_launch::int AS "timeAfterLaunch",
-                    (CASE WHEN instance_id IS NOT NULL THEN date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch') ELSE false END) AS "isDayOne",
-                    (CASE WHEN instance_id IS NOT NULL THEN date_completed < COALESCE(contest_end, TIMESTAMP 'epoch') ELSE false END) AS "isContest",
-                    (CASE WHEN instance_id IS NOT NULL THEN date_completed < COALESCE(week_one_end, TIMESTAMP 'epoch') ELSE false END) AS "isWeekOne",
-                    COALESCE(is_challenge_mode, false) AS "isChallengeMode"
-                FROM world_first_contest_leaderboard
-                JOIN activity_definition ON world_first_contest_leaderboard.activity_id = activity_definition.id
-                WHERE membership_ids @> $1::jsonb
-                    AND rank <= 500
+                    wf.rank::int AS "rank",
+                    wf.instance_id AS "instanceId",
+                    wf.time_after_launch::int AS "timeAfterLaunch",
+                    (CASE WHEN wf.instance_id IS NOT NULL THEN wf.date_completed < COALESCE(activity_definition.day_one_end, TIMESTAMP 'epoch') ELSE false END) AS "isDayOne",
+                    (
+                        CASE
+                            WHEN wf.instance_id IS NULL THEN false
+                            WHEN wf_cact.activity_id IS NOT NULL THEN (
+                                av.version_id = 32
+                                AND i.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
+                            )
+                            ELSE i.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
+                        END
+                    ) AS "isContest",
+                    (CASE WHEN wf.instance_id IS NOT NULL THEN wf.date_completed < COALESCE(activity_definition.week_one_end, TIMESTAMP 'epoch') ELSE false END) AS "isWeekOne",
+                    COALESCE(wf.is_challenge_mode, false) AS "isChallengeMode"
+                FROM world_first_contest_leaderboard wf
+                JOIN activity_definition ON wf.activity_id = activity_definition.id
+                LEFT JOIN instance i ON i.instance_id = wf.instance_id
+                LEFT JOIN activity_version av ON av.hash = i.hash
+                LEFT JOIN (
+                    SELECT DISTINCT av2.activity_id
+                    FROM activity_version av2
+                    WHERE av2.version_id = 32
+                ) wf_cact ON wf_cact.activity_id = activity_definition.id
+                WHERE wf.membership_ids @> $1::jsonb
+                    AND wf.rank <= 500
                     AND activity_definition.is_raid = true
-                ORDER BY activity_definition.id ASC, rank ASC;`,
+                ORDER BY activity_definition.id ASC, wf.rank ASC;`,
                 { params: [`${[membershipId]}`] }
             )
     )

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -56,7 +56,7 @@ export const getPlayerActivityStats = async (membershipId: bigint | string) => {
                             'season', fastest.season_id::int,
                             'duration', fastest.duration::int,
                             'platformType', fastest.platform_type,
-                            'isDayOne', date_completed < COALESCE(day_one_end, TIMESTAMP 'epoch'),
+                            'isDayOne', fastest.date_completed < COALESCE(activity_definition.day_one_end, TIMESTAMP 'epoch'),
                             'isContest', (
                                 CASE
                                     WHEN fa_cact.activity_id IS NOT NULL THEN (
@@ -66,7 +66,7 @@ export const getPlayerActivityStats = async (membershipId: bigint | string) => {
                                     ELSE fastest.date_completed < COALESCE(activity_definition.contest_end, TIMESTAMP 'epoch')
                                 END
                             ),
-                            'isWeekOne', date_completed < COALESCE(week_one_end, TIMESTAMP 'epoch'),
+                            'isWeekOne', fastest.date_completed < COALESCE(activity_definition.week_one_end, TIMESTAMP 'epoch'),
                             'isBlacklisted', bi.instance_id IS NOT NULL
                         )
                         ELSE NULL


### PR DESCRIPTION
## Summary

`isContest` used to mean “completed before `contest_end`” for every clear. That is incorrect for raids that expose a **separate Standard hash** during the same calendar window (e.g. Desert Perpetual): a Standard clear should not be treated as contest mode.

This PR aligns `isContest` with catalog semantics:

- If the activity has **any** `activity_version` row with **`version_id = 32`** (Contest), then **`isContest`** is true only when this instance’s **`activity_version.version_id`** is **32** and **`date_completed`** is still before **`contest_end`**.
- Otherwise (**legacy raids** with no v32 row for that activity), **`isContest`** stays **date-only** vs `contest_end`.

## Implementation

- **SQL**: `LEFT JOIN` a small `DISTINCT activity_id` subquery for activities that offer v32, then branch on `av.version_id = 32` + `contest_end` vs legacy `date_completed < contest_end`.
- **Call sites**: `getInstance`, `getInstances`, `getActivities` (history), `getPlayerActivityStats` (fastest instance JSON), `getWorldFirstEntries` (join `instance` + `activity_version` for version-aware flag).
- **Docs**: `Instance.isContest` OpenAPI / Zod description updated; `openapi.json` kept in sync.

**Contest version id** is the existing catalog constant **32** (same as `version_definition` id for “Contest” in Services seed data).

## Tests

- **`instance.test.ts`**: regression coverage modeled on public PGCR [16326292274](https://raidhub.io/pgcr/16326292274) (Desert Perpetual Standard mid-window → `isContest` false; contest hash → true; Vow Standard pre-`contest_end` → legacy true). Optional assertion when instance `16326292274` exists in the DB under test.

## Deploy / ops

- No migration. Requires **`definitions.activity_version`** to already include the expected **15 / 1**, **15 / 32**, and **10 / 1** rows (normal Services migrations + seeds).

## Checklist

- [ ] `bun test src/services/instance/instance.test.ts` (and full suite) against a DB with definitions seeded
