### PR TITLE
Fix parsing of the comma-separated `membershipIds` query param

### DIFF
--- a/src/routes/player/membershipId/instances.ts
+++ b/src/routes/player/membershipId/instances.ts
@@ -23,10 +23,12 @@ export const playerInstancesRoute = new RaidHubRoute({
         membershipId: zBigIntString()
     }),
     query: z.object({
-        membershipIds: zSplitCommaSeparatedString(zBigIntString()).max(6).default([]).openapi({
-            description:
-                "A comma-separated list of up to 6 membershipIds the must be present in the instance. You do not need to include the target membershipId from the path parameter in this list."
-        }),
+        membershipIds: zSplitCommaSeparatedString(zBigIntString(), a =>
+            a.max(6).default([]).openapi({
+                description:
+                    "A comma-separated list of up to 6 membershipIds the must be present in the instance. You do not need to include the target membershipId from the path parameter in this list."
+            })
+        ),
         activityId: zCoercedNaturalNumber().optional(),
         versionId: zCoercedNaturalNumber().optional(),
         completed: zBoolString().optional(),

--- a/src/schema/input.test.ts
+++ b/src/schema/input.test.ts
@@ -1,6 +1,7 @@
 import "@/schema/registry" // Initialize OpenAPI extensions
 import { describe, expect, test } from "bun:test"
-import { zBoolString } from "./input"
+import { z } from "zod"
+import { zBigIntString, zBoolString, zSplitCommaSeparatedString } from "./input"
 
 describe("zBoolString", () => {
     test("should parse truthy values correctly", () => {
@@ -36,6 +37,143 @@ describe("zBoolString", () => {
         invalidValues.forEach(value => {
             const result = schema.safeParse(value)
             expect(result.success).toBe(false)
+        })
+    })
+})
+
+describe("zSplitCommaSeparatedString", () => {
+    test("should fail on non-string non-array input", () => {
+        const schema = zSplitCommaSeparatedString(z.any())
+        const nonStringValues = [
+            123,
+            1234567890123456789012345678901234567890123456789012345678901234567890n,
+            0,
+            NaN,
+            {},
+            null,
+            undefined
+        ]
+
+        nonStringValues.forEach(value => {
+            const result = schema.safeParse(value)
+            expect(result.success).toBe(false)
+        })
+    })
+
+    test("should coerce empty string to an array with one empty string element", () => {
+        const schema = zSplitCommaSeparatedString(z.any())
+        const inputValue = ""
+
+        const result = schema.safeParse(inputValue)
+        expect(result.success).toBe(true)
+        if (result.success) {
+            expect(result.data).toEqual([""])
+        }
+    })
+
+    test("should split comma-separated values", () => {
+        const schema = zSplitCommaSeparatedString(z.any())
+        const inputValue = "qwe,123,null,NaN,undefined"
+
+        const result = schema.safeParse(inputValue)
+        expect(result.success).toBe(true)
+        if (result.success) {
+            expect(result.data).toEqual(["qwe", "123", "null", "NaN", "undefined"])
+        }
+    })
+
+    test("should fail on elements not passing the array-item schema", () => {
+        const schema = zSplitCommaSeparatedString(zBigIntString())
+        const nonconformingInputs = ["", "nah", ",", "123,", "123123123,notanumber"]
+
+        nonconformingInputs.forEach(value => {
+            const result = schema.safeParse(value)
+            expect(result.success).toBe(false)
+        })
+    })
+
+    test("should pass on a valid single-value input", () => {
+        const schema = zSplitCommaSeparatedString(zBigIntString())
+        const singleValueInput = [
+            { input: "123", expected: [123n] },
+            {
+                input: "1234567890123456789012345678901234567890123456789012345678901234567890",
+                expected: [1234567890123456789012345678901234567890123456789012345678901234567890n]
+            }
+        ]
+
+        singleValueInput.forEach(value => {
+            const result = schema.safeParse(value.input)
+            expect(result.success).toBe(true)
+            if (result.success) {
+                expect(result.data).toEqual(value.expected)
+            }
+        })
+    })
+
+    test("should pass on a valid multi-value input", () => {
+        const schema = zSplitCommaSeparatedString(zBigIntString())
+        const singleValueInput = [
+            { input: "123,123,123", expected: [123n, 123n, 123n] },
+            {
+                input: "123,1234567890123456789012345678901234567890123456789012345678901234567890",
+                expected: [
+                    123n,
+                    1234567890123456789012345678901234567890123456789012345678901234567890n
+                ]
+            },
+            {
+                input: "11234567890123456789012345678901234567890123456789012345678901234567890,21234567890123456789012345678901234567890123456789012345678901234567890,31234567890123456789012345678901234567890123456789012345678901234567890",
+                expected: [
+                    1_1234567890123456789012345678901234567890123456789012345678901234567890n,
+                    2_1234567890123456789012345678901234567890123456789012345678901234567890n,
+                    3_1234567890123456789012345678901234567890123456789012345678901234567890n
+                ]
+            }
+        ]
+
+        singleValueInput.forEach(value => {
+            const result = schema.safeParse(value.input)
+            expect(result.success).toBe(true)
+            if (result.success) {
+                expect(result.data).toEqual(value.expected)
+            }
+        })
+    })
+
+    test("should not fail parsing on excessive spaces", () => {
+        const schema = zSplitCommaSeparatedString(zBigIntString())
+        const validValuesWithExtraSpaces = [
+            { input: " 123", expected: [123n] },
+            { input: "123 ", expected: [123n] },
+            { input: " 123 ", expected: [123n] },
+            {
+                input: " 1234567890123456789012345678901234567890123456789012345678901234567890",
+                expected: [1234567890123456789012345678901234567890123456789012345678901234567890n]
+            },
+            {
+                input: "1234567890123456789012345678901234567890123456789012345678901234567890 ",
+                expected: [1234567890123456789012345678901234567890123456789012345678901234567890n]
+            },
+            {
+                input: " 1234567890123456789012345678901234567890123456789012345678901234567890 ",
+                expected: [1234567890123456789012345678901234567890123456789012345678901234567890n]
+            },
+            {
+                input: "  123  ,  1234567890123456789012345678901234567890123456789012345678901234567890  ",
+                expected: [
+                    123n,
+                    1234567890123456789012345678901234567890123456789012345678901234567890n
+                ]
+            }
+        ]
+
+        validValuesWithExtraSpaces.forEach(value => {
+            const result = schema.safeParse(value.input)
+            expect(result.success).toBe(true)
+            if (result.success) {
+                expect(result.data).toEqual(value.expected)
+            }
         })
     })
 })

--- a/src/schema/input.test.ts
+++ b/src/schema/input.test.ts
@@ -176,4 +176,19 @@ describe("zSplitCommaSeparatedString", () => {
             }
         })
     })
+
+    test("should pass an input array, but still checks the items", () => {
+        const schema = zSplitCommaSeparatedString(zBigIntString())
+        const invalidArrayInput = [123123n, "qweqwe"]
+        const validArrayInput = [123, 123123]
+
+        const invalidResult = schema.safeParse(invalidArrayInput)
+        expect(invalidResult.success).toBe(false)
+
+        const validResult = schema.safeParse(validArrayInput)
+        expect(validResult.success).toBe(true)
+        if (validResult.success) {
+            expect(validResult.data).toEqual([123n, 123123n])
+        }
+    })
 })

--- a/src/schema/input.ts
+++ b/src/schema/input.ts
@@ -1,4 +1,4 @@
-import { ZodBooleanDef, ZodDateDef, ZodNullable, ZodStringDef, ZodType, ZodTypeAny, z } from "zod"
+import { ZodBooleanDef, ZodDateDef, ZodNullable, ZodStringDef, ZodType, ZodTypeAny, z, ZodArray } from "zod"
 
 // ===== INPUT SCHEMAS (for parsing/coercing user input) =====
 
@@ -44,12 +44,21 @@ export const zDigitString = () =>
 // Input param that will be coerced to a BigInt
 export const zBigIntString = () => zDigitString().transform(val => BigInt(val))
 
-export const zSplitCommaSeparatedString = <T extends ZodTypeAny>(schema: T) =>
-    z.array(
-        z.preprocess(val => {
+export const zSplitCommaSeparatedString = <T extends ZodTypeAny, ResultingArray extends ZodTypeAny>(
+    itemSchema: T,
+    extendArraySchema?: (arraySchema: z.ZodArray<T>) => ResultingArray
+) => {
+    const finalArraySchema = extendArraySchema
+        ? extendArraySchema(z.array(itemSchema))
+        : z.array(itemSchema)
+
+    return z.preprocess(
+        val => {
             if (typeof val === "string") {
-                return val.split(",")
+                return val.split(",").map(s => s.trim())
             }
             return val
-        }, schema)
+        },
+        finalArraySchema
     )
+}


### PR DESCRIPTION
Instance Finder API does not correctly preprocess `membershipIds` comma-separated string due to wrong Zod schema implementation.

1. Fixed the schema and changed the way of extending the target schema of the `z.preprocess` (since it returns `ZodEffect` instead of a type)
2. Added white-space trimming of comma-separated values
3. Covered with a few tests (5 are failing without the fix)
<img width="668" height="392" alt="image" src="https://github.com/user-attachments/assets/83901bdc-bd50-463a-a309-2c05745b3b28" />


<hr/>
`z.array(z.preprocess(...))` expects an array an fails on string input 
<img width="541" height="455" alt="image" src="https://github.com/user-attachments/assets/c25c29f7-8717-496d-9fd4-98f3aeb12867" />

<hr/>
"Profile/Instance Finder" fails on any query containing another IDs
`https://api.raidhub.io/player/<USER_ID>/instances?membershipIds=<COMMA_SEPARATED_IDS>`
<img width="352" height="489" alt="image" src="https://github.com/user-attachments/assets/d1bf3b3e-eb05-45b8-b376-e5b368e7df52" />
