### PR TITLE
feat(pantheon): Pantheon 2.0 modes and manifest-driven version lookup

### DIFF
--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -1544,13 +1544,6 @@
             "path": "morgeth",
             "associatedActivityId": 102,
             "isChallengeMode": false
-          },
-          {
-            "id": 134,
-            "name": "Pantheon Gauntlet",
-            "path": "gauntlet",
-            "associatedActivityId": 102,
-            "isChallengeMode": false
           }
         ]
       },

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -2241,15 +2241,6 @@
             "minItems": 1,
             "description": "The list of activityId for Pantheon"
           },
-          "gauntletVersionIds": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "minimum": 0,
-              "exclusiveMinimum": true
-            },
-            "description": "The list of versionId for Pantheon gauntlet modes (full boss lineup)"
-          },
           "versionsForActivity": {
             "type": "object",
             "additionalProperties": {
@@ -2313,7 +2304,6 @@
           "resprisedRaidIds",
           "resprisedChallengeVersionIds",
           "pantheonIds",
-          "gauntletVersionIds",
           "versionsForActivity",
           "rankingTiers",
           "feats",

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -1356,19 +1356,47 @@
         ],
         "additionalProperties": false,
         "description": "The definition of an activity in the RaidHub database.",
-        "example": {
-          "id": 9,
-          "name": "Vault of Glass",
-          "path": "vaultofglass",
-          "isSunset": false,
-          "isRaid": true,
-          "releaseDate": "2021-05-22T00:00:00.000Z",
-          "dayOneEnd": "2021-05-23T00:00:00.000Z",
-          "contestEnd": "2021-05-23T00:00:00.000Z",
-          "weekOneEnd": "2021-05-25T00:00:00.000Z",
-          "milestoneHash": 1888320892,
-          "splashSlug": "vog"
-        }
+        "examples": [
+          {
+            "id": 9,
+            "name": "Vault of Glass",
+            "path": "vaultofglass",
+            "isSunset": false,
+            "isRaid": true,
+            "releaseDate": "2021-05-22T00:00:00.000Z",
+            "dayOneEnd": "2021-05-23T00:00:00.000Z",
+            "contestEnd": "2021-05-23T00:00:00.000Z",
+            "weekOneEnd": "2021-05-25T00:00:00.000Z",
+            "milestoneHash": 1888320892,
+            "splashSlug": "vog"
+          },
+          {
+            "id": 101,
+            "name": "The Pantheon",
+            "path": "pantheon",
+            "isSunset": true,
+            "isRaid": false,
+            "releaseDate": "2024-04-30T17:00:00.000Z",
+            "dayOneEnd": null,
+            "contestEnd": null,
+            "weekOneEnd": null,
+            "milestoneHash": null,
+            "splashSlug": "pantheon"
+          },
+          {
+            "id": 102,
+            "name": "Pantheon",
+            "path": "pantheon",
+            "isSunset": false,
+            "isRaid": false,
+            "releaseDate": "2026-06-09T17:00:00.000Z",
+            "dayOneEnd": null,
+            "contestEnd": null,
+            "weekOneEnd": null,
+            "milestoneHash": null,
+            "splashSlug": "pantheon"
+          }
+        ]
       },
       "FeatDefinition": {
         "type": "object",
@@ -1501,6 +1529,27 @@
             "name": "Oryx Exalted",
             "path": "oryx",
             "associatedActivityId": 101,
+            "isChallengeMode": false
+          },
+          {
+            "id": 132,
+            "name": "Calus Resplendent",
+            "path": "calus",
+            "associatedActivityId": 102,
+            "isChallengeMode": false
+          },
+          {
+            "id": 133,
+            "name": "Morgeth Surpassing",
+            "path": "morgeth",
+            "associatedActivityId": 102,
+            "isChallengeMode": false
+          },
+          {
+            "id": 134,
+            "name": "Pantheon Gauntlet",
+            "path": "gauntlet",
+            "associatedActivityId": 102,
             "isChallengeMode": false
           }
         ]
@@ -2199,6 +2248,15 @@
             "minItems": 1,
             "description": "The list of activityId for Pantheon"
           },
+          "gauntletVersionIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "description": "The list of versionId for Pantheon gauntlet modes (full boss lineup)"
+          },
           "versionsForActivity": {
             "type": "object",
             "additionalProperties": {
@@ -2262,6 +2320,7 @@
           "resprisedRaidIds",
           "resprisedChallengeVersionIds",
           "pantheonIds",
+          "gauntletVersionIds",
           "versionsForActivity",
           "rankingTiers",
           "feats",

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -2241,6 +2241,15 @@
             "minItems": 1,
             "description": "The list of activityId for Pantheon"
           },
+          "gauntletVersionIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "description": "The list of versionId for Pantheon gauntlet modes (full boss lineup)"
+          },
           "versionsForActivity": {
             "type": "object",
             "additionalProperties": {
@@ -2304,6 +2313,7 @@
           "resprisedRaidIds",
           "resprisedChallengeVersionIds",
           "pantheonIds",
+          "gauntletVersionIds",
           "versionsForActivity",
           "rankingTiers",
           "feats",

--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -1373,7 +1373,7 @@
           {
             "id": 101,
             "name": "The Pantheon",
-            "path": "pantheon",
+            "path": "thepantheon",
             "isSunset": true,
             "isRaid": false,
             "releaseDate": "2024-04-30T17:00:00.000Z",
@@ -2241,15 +2241,6 @@
             "minItems": 1,
             "description": "The list of activityId for Pantheon"
           },
-          "gauntletVersionIds": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "minimum": 0,
-              "exclusiveMinimum": true
-            },
-            "description": "The list of versionId for Pantheon gauntlet modes (full boss lineup)"
-          },
           "versionsForActivity": {
             "type": "object",
             "additionalProperties": {
@@ -2313,7 +2304,6 @@
           "resprisedRaidIds",
           "resprisedChallengeVersionIds",
           "pantheonIds",
-          "gauntletVersionIds",
           "versionsForActivity",
           "rankingTiers",
           "feats",

--- a/src/routes/leaderboard/individual/pantheon.test.ts
+++ b/src/routes/leaderboard/individual/pantheon.test.ts
@@ -21,6 +21,18 @@ describe("pantheon leaderboard 200", () => {
         }
     }
 
+    test("calus", () =>
+        t(
+            {
+                category: "freshClears",
+                version: "calus"
+            },
+            {
+                count: 10,
+                page: 1
+            }
+        ))
+
     test("clears", () =>
         t(
             {

--- a/src/routes/leaderboard/individual/pantheon.test.ts
+++ b/src/routes/leaderboard/individual/pantheon.test.ts
@@ -21,18 +21,6 @@ describe("pantheon leaderboard 200", () => {
         }
     }
 
-    test("calus", () =>
-        t(
-            {
-                category: "freshClears",
-                version: "calus"
-            },
-            {
-                count: 10,
-                page: 1
-            }
-        ))
-
     test("clears", () =>
         t(
             {

--- a/src/routes/leaderboard/individual/pantheon.ts
+++ b/src/routes/leaderboard/individual/pantheon.ts
@@ -9,7 +9,7 @@ import {
     individualPantheonLeaderboardSortColumns,
     searchIndividualPantheonLeaderboard
 } from "@/services/leaderboard/individual/pantheon"
-import { getVersionId } from "@/services/manifest/definitions"
+import { getPantheonVersionId } from "@/services/manifest/pantheon"
 import { z } from "zod"
 
 const zCategory = z.enum(["clears", "freshClears", "score"])
@@ -59,7 +59,7 @@ export const leaderboardIndividualPantheonRoute = new RaidHubRoute({
 
         const { page, count, search } = req.query
 
-        const versionDefinition = await getVersionId(version, 101)
+        const versionDefinition = await getPantheonVersionId(version)
 
         if (!versionDefinition) {
             return RaidHubRoute.fail(ErrorCode.PantheonVersionNotFoundError, {

--- a/src/routes/manifest.ts
+++ b/src/routes/manifest.ts
@@ -11,11 +11,7 @@ import {
     listHashes,
     listVersionDefinitions
 } from "@/services/manifest/definitions"
-import {
-    getGauntletVersionIds,
-    getPantheonActivityIds,
-    sortPantheonActivityIds
-} from "@/services/manifest/pantheon"
+import { getPantheonActivityIds, sortPantheonActivityIds } from "@/services/manifest/pantheon"
 import { TierBreaks } from "@/services/manifest/tiers"
 import { generateSplashUrls } from "@/services/manifest/urls"
 import { z } from "zod"
@@ -92,12 +88,6 @@ export const manifestRoute = new RaidHubRoute({
                             description: "The list of activityId for Pantheon"
                         })
                         .min(1),
-                    gauntletVersionIds: z
-                        .array(zNaturalNumber())
-                        .openapi({
-                            description:
-                                "The list of versionId for Pantheon gauntlet modes (full boss lineup)"
-                        }),
                     versionsForActivity: z.record(z.array(zNaturalNumber()).min(1)).openapi({
                         description: "The set of versionId for each activityId"
                     }),
@@ -132,7 +122,6 @@ export const manifestRoute = new RaidHubRoute({
         ])
         const raids = activities.filter(a => a.isRaid)
         const pantheonIds = sortPantheonActivityIds(activities, getPantheonActivityIds(activities))
-        const gauntletVersionIds = getGauntletVersionIds(versions, pantheonIds)
         const versionsSetForActivity: Record<number, Set<number>> = {}
         for (const { activityId, versionId } of hashes) {
             if (!versionsSetForActivity[activityId]) {
@@ -179,7 +168,6 @@ export const manifestRoute = new RaidHubRoute({
                 .map(a => a.associatedActivityId!),
             resprisedChallengeVersionIds: versions.filter(v => v.isChallengeMode).map(v => v.id),
             pantheonIds,
-            gauntletVersionIds,
             versionsForActivity: versionsForActivity,
             rankingTiers: TierBreaks,
             feats: feats,

--- a/src/routes/manifest.ts
+++ b/src/routes/manifest.ts
@@ -11,7 +11,11 @@ import {
     listHashes,
     listVersionDefinitions
 } from "@/services/manifest/definitions"
-import { getPantheonActivityIds, sortPantheonActivityIds } from "@/services/manifest/pantheon"
+import {
+    getGauntletVersionIds,
+    getPantheonActivityIds,
+    sortPantheonActivityIds
+} from "@/services/manifest/pantheon"
 import { TierBreaks } from "@/services/manifest/tiers"
 import { generateSplashUrls } from "@/services/manifest/urls"
 import { z } from "zod"
@@ -88,6 +92,10 @@ export const manifestRoute = new RaidHubRoute({
                             description: "The list of activityId for Pantheon"
                         })
                         .min(1),
+                    gauntletVersionIds: z.array(zNaturalNumber()).openapi({
+                        description:
+                            "The list of versionId for Pantheon gauntlet modes (full boss lineup)"
+                    }),
                     versionsForActivity: z.record(z.array(zNaturalNumber()).min(1)).openapi({
                         description: "The set of versionId for each activityId"
                     }),
@@ -122,6 +130,7 @@ export const manifestRoute = new RaidHubRoute({
         ])
         const raids = activities.filter(a => a.isRaid)
         const pantheonIds = sortPantheonActivityIds(activities, getPantheonActivityIds(activities))
+        const gauntletVersionIds = getGauntletVersionIds(versions, pantheonIds)
         const versionsSetForActivity: Record<number, Set<number>> = {}
         for (const { activityId, versionId } of hashes) {
             if (!versionsSetForActivity[activityId]) {
@@ -168,6 +177,7 @@ export const manifestRoute = new RaidHubRoute({
                 .map(a => a.associatedActivityId!),
             resprisedChallengeVersionIds: versions.filter(v => v.isChallengeMode).map(v => v.id),
             pantheonIds,
+            gauntletVersionIds,
             versionsForActivity: versionsForActivity,
             rankingTiers: TierBreaks,
             feats: feats,

--- a/src/routes/manifest.ts
+++ b/src/routes/manifest.ts
@@ -11,7 +11,11 @@ import {
     listHashes,
     listVersionDefinitions
 } from "@/services/manifest/definitions"
-import { getPantheonActivityIds, sortPantheonActivityIds } from "@/services/manifest/pantheon"
+import {
+    getGauntletVersionIds,
+    getPantheonActivityIds,
+    sortPantheonActivityIds
+} from "@/services/manifest/pantheon"
 import { TierBreaks } from "@/services/manifest/tiers"
 import { generateSplashUrls } from "@/services/manifest/urls"
 import { z } from "zod"
@@ -88,6 +92,12 @@ export const manifestRoute = new RaidHubRoute({
                             description: "The list of activityId for Pantheon"
                         })
                         .min(1),
+                    gauntletVersionIds: z
+                        .array(zNaturalNumber())
+                        .openapi({
+                            description:
+                                "The list of versionId for Pantheon gauntlet modes (full boss lineup)"
+                        }),
                     versionsForActivity: z.record(z.array(zNaturalNumber()).min(1)).openapi({
                         description: "The set of versionId for each activityId"
                     }),
@@ -122,6 +132,7 @@ export const manifestRoute = new RaidHubRoute({
         ])
         const raids = activities.filter(a => a.isRaid)
         const pantheonIds = sortPantheonActivityIds(activities, getPantheonActivityIds(activities))
+        const gauntletVersionIds = getGauntletVersionIds(versions, pantheonIds)
         const versionsSetForActivity: Record<number, Set<number>> = {}
         for (const { activityId, versionId } of hashes) {
             if (!versionsSetForActivity[activityId]) {
@@ -168,6 +179,7 @@ export const manifestRoute = new RaidHubRoute({
                 .map(a => a.associatedActivityId!),
             resprisedChallengeVersionIds: versions.filter(v => v.isChallengeMode).map(v => v.id),
             pantheonIds,
+            gauntletVersionIds,
             versionsForActivity: versionsForActivity,
             rankingTiers: TierBreaks,
             feats: feats,

--- a/src/routes/manifest.ts
+++ b/src/routes/manifest.ts
@@ -11,6 +11,11 @@ import {
     listHashes,
     listVersionDefinitions
 } from "@/services/manifest/definitions"
+import {
+    getGauntletVersionIds,
+    getPantheonActivityIds,
+    sortPantheonActivityIds
+} from "@/services/manifest/pantheon"
 import { TierBreaks } from "@/services/manifest/tiers"
 import { generateSplashUrls } from "@/services/manifest/urls"
 import { z } from "zod"
@@ -87,6 +92,12 @@ export const manifestRoute = new RaidHubRoute({
                             description: "The list of activityId for Pantheon"
                         })
                         .min(1),
+                    gauntletVersionIds: z
+                        .array(zNaturalNumber())
+                        .openapi({
+                            description:
+                                "The list of versionId for Pantheon gauntlet modes (full boss lineup)"
+                        }),
                     versionsForActivity: z.record(z.array(zNaturalNumber()).min(1)).openapi({
                         description: "The set of versionId for each activityId"
                     }),
@@ -120,7 +131,8 @@ export const manifestRoute = new RaidHubRoute({
             activitiesPromise.then(generateSplashUrls)
         ])
         const raids = activities.filter(a => a.isRaid)
-        const pantheonId = 101
+        const pantheonIds = sortPantheonActivityIds(activities, getPantheonActivityIds(activities))
+        const gauntletVersionIds = getGauntletVersionIds(versions, pantheonIds)
         const versionsSetForActivity: Record<number, Set<number>> = {}
         for (const { activityId, versionId } of hashes) {
             if (!versionsSetForActivity[activityId]) {
@@ -166,7 +178,8 @@ export const manifestRoute = new RaidHubRoute({
                 .filter(v => v.associatedActivityId && v.associatedActivityId < 100)
                 .map(a => a.associatedActivityId!),
             resprisedChallengeVersionIds: versions.filter(v => v.isChallengeMode).map(v => v.id),
-            pantheonIds: [pantheonId],
+            pantheonIds,
+            gauntletVersionIds,
             versionsForActivity: versionsForActivity,
             rankingTiers: TierBreaks,
             feats: feats,

--- a/src/schema/components/ActivityDefinition.ts
+++ b/src/schema/components/ActivityDefinition.ts
@@ -22,18 +22,46 @@ export const zActivityDefinition = registry.register(
         .strict()
         .openapi({
             description: "The definition of an activity in the RaidHub database.",
-            example: {
-                id: 9,
-                name: "Vault of Glass",
-                path: "vaultofglass",
-                isSunset: false,
-                isRaid: true,
-                releaseDate: new Date("2021-05-22T00:00:00Z"),
-                dayOneEnd: new Date("2021-05-23T00:00:00Z"),
-                contestEnd: new Date("2021-05-23T00:00:00Z"),
-                weekOneEnd: new Date("2021-05-25T00:00:00Z"),
-                milestoneHash: 1888320892,
-                splashSlug: "vog"
-            }
+            examples: [
+                {
+                    id: 9,
+                    name: "Vault of Glass",
+                    path: "vaultofglass",
+                    isSunset: false,
+                    isRaid: true,
+                    releaseDate: new Date("2021-05-22T00:00:00Z"),
+                    dayOneEnd: new Date("2021-05-23T00:00:00Z"),
+                    contestEnd: new Date("2021-05-23T00:00:00Z"),
+                    weekOneEnd: new Date("2021-05-25T00:00:00Z"),
+                    milestoneHash: 1888320892,
+                    splashSlug: "vog"
+                },
+                {
+                    id: 101,
+                    name: "The Pantheon",
+                    path: "pantheon",
+                    isSunset: true,
+                    isRaid: false,
+                    releaseDate: new Date("2024-04-30T17:00:00Z"),
+                    dayOneEnd: null,
+                    contestEnd: null,
+                    weekOneEnd: null,
+                    milestoneHash: null,
+                    splashSlug: "pantheon"
+                },
+                {
+                    id: 102,
+                    name: "Pantheon",
+                    path: "pantheon",
+                    isSunset: false,
+                    isRaid: false,
+                    releaseDate: new Date("2026-06-09T17:00:00Z"),
+                    dayOneEnd: null,
+                    contestEnd: null,
+                    weekOneEnd: null,
+                    milestoneHash: null,
+                    splashSlug: "pantheon"
+                }
+            ]
         })
 )

--- a/src/schema/components/ActivityDefinition.ts
+++ b/src/schema/components/ActivityDefinition.ts
@@ -39,7 +39,7 @@ export const zActivityDefinition = registry.register(
                 {
                     id: 101,
                     name: "The Pantheon",
-                    path: "pantheon",
+                    path: "thepantheon",
                     isSunset: true,
                     isRaid: false,
                     releaseDate: new Date("2024-04-30T17:00:00Z"),

--- a/src/schema/components/VersionDefinition.ts
+++ b/src/schema/components/VersionDefinition.ts
@@ -30,6 +30,27 @@ export const zVersionDefinition = registry.register(
                     path: "oryx",
                     associatedActivityId: 101,
                     isChallengeMode: false
+                },
+                {
+                    id: 132,
+                    name: "Calus Resplendent",
+                    path: "calus",
+                    associatedActivityId: 102,
+                    isChallengeMode: false
+                },
+                {
+                    id: 133,
+                    name: "Morgeth Surpassing",
+                    path: "morgeth",
+                    associatedActivityId: 102,
+                    isChallengeMode: false
+                },
+                {
+                    id: 134,
+                    name: "Pantheon Gauntlet",
+                    path: "gauntlet",
+                    associatedActivityId: 102,
+                    isChallengeMode: false
                 }
             ]
         })

--- a/src/schema/components/VersionDefinition.ts
+++ b/src/schema/components/VersionDefinition.ts
@@ -44,13 +44,6 @@ export const zVersionDefinition = registry.register(
                     path: "morgeth",
                     associatedActivityId: 102,
                     isChallengeMode: false
-                },
-                {
-                    id: 134,
-                    name: "Pantheon Gauntlet",
-                    path: "gauntlet",
-                    associatedActivityId: 102,
-                    isChallengeMode: false
                 }
             ]
         })

--- a/src/services/manifest/definitions.ts
+++ b/src/services/manifest/definitions.ts
@@ -4,6 +4,13 @@ import { ActivityDefinition } from "@/schema/components/ActivityDefinition"
 import { FeatDefinition } from "@/schema/components/FeatDefinition"
 import { VersionDefinition } from "@/schema/components/VersionDefinition"
 
+export const getActivityIdByPath = async (activityPath: string) => {
+    return await pgReader.queryRow<{ id: number }>(
+        `SELECT id::int FROM activity_definition WHERE path = $1`,
+        { params: [activityPath] }
+    )
+}
+
 export const getRaidId = async (raidPath: string) => {
     return await pgReader.queryRow<{ id: number }>(
         `SELECT id::int FROM activity_definition WHERE path = $1 AND is_raid`,

--- a/src/services/manifest/pantheon.test.ts
+++ b/src/services/manifest/pantheon.test.ts
@@ -1,4 +1,9 @@
-import { getPantheonActivityIds, sortPantheonActivityIds } from "@/services/manifest/pantheon"
+import {
+    GAUNTLET_VERSION_PATH,
+    getGauntletVersionIds,
+    getPantheonActivityIds,
+    sortPantheonActivityIds
+} from "@/services/manifest/pantheon"
 import { describe, expect, test } from "bun:test"
 
 const pantheonActivity = {
@@ -70,5 +75,31 @@ describe("sortPantheonActivityIds", () => {
                 [101, 102]
             )
         ).toEqual([102, 101])
+    })
+})
+
+describe("getGauntletVersionIds", () => {
+    test("returns gauntlet versions associated with pantheon activities", () => {
+        expect(
+            getGauntletVersionIds(
+                [
+                    {
+                        id: 129,
+                        name: "Oryx Exalted",
+                        path: "oryx",
+                        associatedActivityId: 101,
+                        isChallengeMode: false
+                    },
+                    {
+                        id: 200,
+                        name: "Gauntlet Mode",
+                        path: GAUNTLET_VERSION_PATH,
+                        associatedActivityId: 102,
+                        isChallengeMode: false
+                    }
+                ],
+                [101, 102]
+            )
+        ).toEqual([200])
     })
 })

--- a/src/services/manifest/pantheon.test.ts
+++ b/src/services/manifest/pantheon.test.ts
@@ -125,17 +125,11 @@ describe("getGauntletVersionIds", () => {
                     },
 
                     {
-
-                        id: 134,
-
-                        name: "Pantheon Gauntlet",
-
+                        id: 200,
+                        name: "Gauntlet Mode",
                         path: GAUNTLET_VERSION_PATH,
-
                         associatedActivityId: 102,
-
                         isChallengeMode: false
-
                     }
 
                 ],
@@ -144,7 +138,7 @@ describe("getGauntletVersionIds", () => {
 
             )
 
-        ).toEqual([134])
+        ).toEqual([200])
 
     })
 

--- a/src/services/manifest/pantheon.test.ts
+++ b/src/services/manifest/pantheon.test.ts
@@ -1,0 +1,153 @@
+import {
+    GAUNTLET_VERSION_PATH,
+    getGauntletVersionIds,
+    getPantheonActivityIds,
+    sortPantheonActivityIds
+} from "@/services/manifest/pantheon"
+import { describe, expect, test } from "bun:test"
+
+
+
+const pantheonActivity = {
+    isRaid: false,
+    releaseDate: null,
+    dayOneEnd: null,
+    contestEnd: null,
+    weekOneEnd: null,
+    milestoneHash: null,
+    splashSlug: "pantheon"
+} as const
+
+
+describe("getPantheonActivityIds", () => {
+
+    test("returns activities with pantheon path", () => {
+
+        expect(
+
+            getPantheonActivityIds([
+
+                {
+
+                    id: 9,
+
+                    name: "Vault of Glass",
+
+                    path: "vaultofglass",
+
+                    isSunset: false,
+
+                    isRaid: true,
+
+                    releaseDate: null,
+
+                    dayOneEnd: null,
+
+                    contestEnd: null,
+
+                    weekOneEnd: null,
+
+                    milestoneHash: null,
+
+                    splashSlug: "vog"
+
+                },
+
+                {
+                    id: 101,
+                    name: "The Pantheon",
+                    path: "pantheon",
+                    isSunset: true,
+                    ...pantheonActivity
+                },
+                {
+                    id: 102,
+                    name: "Pantheon",
+                    path: "pantheon",
+                    isSunset: false,
+                    ...pantheonActivity
+                }
+            ])
+
+        ).toEqual([101, 102])
+
+    })
+
+})
+
+describe("sortPantheonActivityIds", () => {
+    test("lists active pantheon activities before sunset activities", () => {
+        expect(
+            sortPantheonActivityIds(
+                [
+                    {
+                        id: 101,
+                        name: "The Pantheon",
+                        path: "pantheon",
+                        isSunset: true,
+                        ...pantheonActivity
+                    },
+                    {
+                        id: 102,
+                        name: "Pantheon",
+                        path: "pantheon",
+                        isSunset: false,
+                        ...pantheonActivity
+                    }
+                ],
+                [101, 102]
+            )
+        ).toEqual([102, 101])
+    })
+})
+
+describe("getGauntletVersionIds", () => {
+    test("returns gauntlet versions associated with pantheon activities", () => {
+
+        expect(
+
+            getGauntletVersionIds(
+
+                [
+
+                    {
+
+                        id: 129,
+
+                        name: "Oryx Exalted",
+
+                        path: "oryx",
+
+                        associatedActivityId: 101,
+
+                        isChallengeMode: false
+
+                    },
+
+                    {
+
+                        id: 134,
+
+                        name: "Pantheon Gauntlet",
+
+                        path: GAUNTLET_VERSION_PATH,
+
+                        associatedActivityId: 102,
+
+                        isChallengeMode: false
+
+                    }
+
+                ],
+
+                [101, 102]
+
+            )
+
+        ).toEqual([134])
+
+    })
+
+})
+
+

--- a/src/services/manifest/pantheon.test.ts
+++ b/src/services/manifest/pantheon.test.ts
@@ -1,12 +1,5 @@
-import {
-    GAUNTLET_VERSION_PATH,
-    getGauntletVersionIds,
-    getPantheonActivityIds,
-    sortPantheonActivityIds
-} from "@/services/manifest/pantheon"
+import { getPantheonActivityIds, sortPantheonActivityIds } from "@/services/manifest/pantheon"
 import { describe, expect, test } from "bun:test"
-
-
 
 const pantheonActivity = {
     isRaid: false,
@@ -18,45 +11,27 @@ const pantheonActivity = {
     splashSlug: "pantheon"
 } as const
 
-
 describe("getPantheonActivityIds", () => {
-
-    test("returns activities with pantheon path", () => {
-
+    test("returns activities with pantheon paths", () => {
         expect(
-
             getPantheonActivityIds([
-
                 {
-
                     id: 9,
-
                     name: "Vault of Glass",
-
                     path: "vaultofglass",
-
                     isSunset: false,
-
                     isRaid: true,
-
                     releaseDate: null,
-
                     dayOneEnd: null,
-
                     contestEnd: null,
-
                     weekOneEnd: null,
-
                     milestoneHash: null,
-
                     splashSlug: "vog"
-
                 },
-
                 {
                     id: 101,
                     name: "The Pantheon",
-                    path: "pantheon",
+                    path: "thepantheon",
                     isSunset: true,
                     ...pantheonActivity
                 },
@@ -68,11 +43,8 @@ describe("getPantheonActivityIds", () => {
                     ...pantheonActivity
                 }
             ])
-
         ).toEqual([101, 102])
-
     })
-
 })
 
 describe("sortPantheonActivityIds", () => {
@@ -83,7 +55,7 @@ describe("sortPantheonActivityIds", () => {
                     {
                         id: 101,
                         name: "The Pantheon",
-                        path: "pantheon",
+                        path: "thepantheon",
                         isSunset: true,
                         ...pantheonActivity
                     },
@@ -100,48 +72,3 @@ describe("sortPantheonActivityIds", () => {
         ).toEqual([102, 101])
     })
 })
-
-describe("getGauntletVersionIds", () => {
-    test("returns gauntlet versions associated with pantheon activities", () => {
-
-        expect(
-
-            getGauntletVersionIds(
-
-                [
-
-                    {
-
-                        id: 129,
-
-                        name: "Oryx Exalted",
-
-                        path: "oryx",
-
-                        associatedActivityId: 101,
-
-                        isChallengeMode: false
-
-                    },
-
-                    {
-                        id: 200,
-                        name: "Gauntlet Mode",
-                        path: GAUNTLET_VERSION_PATH,
-                        associatedActivityId: 102,
-                        isChallengeMode: false
-                    }
-
-                ],
-
-                [101, 102]
-
-            )
-
-        ).toEqual([200])
-
-    })
-
-})
-
-

--- a/src/services/manifest/pantheon.test.ts
+++ b/src/services/manifest/pantheon.test.ts
@@ -1,74 +1,105 @@
-import { getPantheonActivityIds, sortPantheonActivityIds } from "@/services/manifest/pantheon"
-import { describe, expect, test } from "bun:test"
-
-const pantheonActivity = {
-    isRaid: false,
-    releaseDate: null,
-    dayOneEnd: null,
-    contestEnd: null,
-    weekOneEnd: null,
-    milestoneHash: null,
-    splashSlug: "pantheon"
-} as const
-
-describe("getPantheonActivityIds", () => {
-    test("returns activities with pantheon paths", () => {
-        expect(
-            getPantheonActivityIds([
-                {
-                    id: 9,
-                    name: "Vault of Glass",
-                    path: "vaultofglass",
-                    isSunset: false,
-                    isRaid: true,
-                    releaseDate: null,
-                    dayOneEnd: null,
-                    contestEnd: null,
-                    weekOneEnd: null,
-                    milestoneHash: null,
-                    splashSlug: "vog"
-                },
-                {
-                    id: 101,
-                    name: "The Pantheon",
-                    path: "thepantheon",
-                    isSunset: true,
-                    ...pantheonActivity
-                },
-                {
-                    id: 102,
-                    name: "Pantheon",
-                    path: "pantheon",
-                    isSunset: false,
-                    ...pantheonActivity
-                }
-            ])
-        ).toEqual([101, 102])
-    })
-})
-
-describe("sortPantheonActivityIds", () => {
-    test("lists active pantheon activities before sunset activities", () => {
-        expect(
-            sortPantheonActivityIds(
-                [
-                    {
-                        id: 101,
-                        name: "The Pantheon",
-                        path: "thepantheon",
-                        isSunset: true,
-                        ...pantheonActivity
-                    },
-                    {
-                        id: 102,
-                        name: "Pantheon",
-                        path: "pantheon",
-                        isSunset: false,
-                        ...pantheonActivity
-                    }
-                ],
-                [101, 102]
-            )
-        ).toEqual([102, 101])
-    })
-})
+import {
+    GAUNTLET_VERSION_PATH,
+    getGauntletVersionIds,
+    getPantheonActivityIds,
+    sortPantheonActivityIds
+} from "@/services/manifest/pantheon"
+import { describe, expect, test } from "bun:test"
+
+const pantheonActivity = {
+    isRaid: false,
+    releaseDate: null,
+    dayOneEnd: null,
+    contestEnd: null,
+    weekOneEnd: null,
+    milestoneHash: null,
+    splashSlug: "pantheon"
+} as const
+
+describe("getPantheonActivityIds", () => {
+    test("returns activities with pantheon paths", () => {
+        expect(
+            getPantheonActivityIds([
+                {
+                    id: 9,
+                    name: "Vault of Glass",
+                    path: "vaultofglass",
+                    isSunset: false,
+                    isRaid: true,
+                    releaseDate: null,
+                    dayOneEnd: null,
+                    contestEnd: null,
+                    weekOneEnd: null,
+                    milestoneHash: null,
+                    splashSlug: "vog"
+                },
+                {
+                    id: 101,
+                    name: "The Pantheon",
+                    path: "thepantheon",
+                    isSunset: true,
+                    ...pantheonActivity
+                },
+                {
+                    id: 102,
+                    name: "Pantheon",
+                    path: "pantheon",
+                    isSunset: false,
+                    ...pantheonActivity
+                }
+            ])
+        ).toEqual([101, 102])
+    })
+})
+
+describe("sortPantheonActivityIds", () => {
+    test("lists active pantheon activities before sunset activities", () => {
+        expect(
+            sortPantheonActivityIds(
+                [
+                    {
+                        id: 101,
+                        name: "The Pantheon",
+                        path: "thepantheon",
+                        isSunset: true,
+                        ...pantheonActivity
+                    },
+                    {
+                        id: 102,
+                        name: "Pantheon",
+                        path: "pantheon",
+                        isSunset: false,
+                        ...pantheonActivity
+                    }
+                ],
+                [101, 102]
+            )
+        ).toEqual([102, 101])
+    })
+})
+
+describe("getGauntletVersionIds", () => {
+    test("returns gauntlet versions associated with pantheon activities", () => {
+        expect(
+            getGauntletVersionIds(
+                [
+                    {
+                        id: 129,
+                        name: "Oryx Exalted",
+                        path: "oryx",
+                        associatedActivityId: 101,
+                        isChallengeMode: false
+                    },
+                    {
+                        id: 200,
+                        name: "Gauntlet Mode",
+                        path: GAUNTLET_VERSION_PATH,
+                        associatedActivityId: 102,
+                        isChallengeMode: false
+                    }
+                ],
+                [101, 102]
+            )
+        ).toEqual([200])
+    })
+})

--- a/src/services/manifest/pantheon.test.ts
+++ b/src/services/manifest/pantheon.test.ts
@@ -1,105 +1,74 @@
-import {
-    GAUNTLET_VERSION_PATH,
-    getGauntletVersionIds,
-    getPantheonActivityIds,
-    sortPantheonActivityIds
-} from "@/services/manifest/pantheon"
-import { describe, expect, test } from "bun:test"
-
-const pantheonActivity = {
-    isRaid: false,
-    releaseDate: null,
-    dayOneEnd: null,
-    contestEnd: null,
-    weekOneEnd: null,
-    milestoneHash: null,
-    splashSlug: "pantheon"
-} as const
-
-describe("getPantheonActivityIds", () => {
-    test("returns activities with pantheon paths", () => {
-        expect(
-            getPantheonActivityIds([
-                {
-                    id: 9,
-                    name: "Vault of Glass",
-                    path: "vaultofglass",
-                    isSunset: false,
-                    isRaid: true,
-                    releaseDate: null,
-                    dayOneEnd: null,
-                    contestEnd: null,
-                    weekOneEnd: null,
-                    milestoneHash: null,
-                    splashSlug: "vog"
-                },
-                {
-                    id: 101,
-                    name: "The Pantheon",
-                    path: "thepantheon",
-                    isSunset: true,
-                    ...pantheonActivity
-                },
-                {
-                    id: 102,
-                    name: "Pantheon",
-                    path: "pantheon",
-                    isSunset: false,
-                    ...pantheonActivity
-                }
-            ])
-        ).toEqual([101, 102])
-    })
-})
-
-describe("sortPantheonActivityIds", () => {
-    test("lists active pantheon activities before sunset activities", () => {
-        expect(
-            sortPantheonActivityIds(
-                [
-                    {
-                        id: 101,
-                        name: "The Pantheon",
-                        path: "thepantheon",
-                        isSunset: true,
-                        ...pantheonActivity
-                    },
-                    {
-                        id: 102,
-                        name: "Pantheon",
-                        path: "pantheon",
-                        isSunset: false,
-                        ...pantheonActivity
-                    }
-                ],
-                [101, 102]
-            )
-        ).toEqual([102, 101])
-    })
-})
-
-describe("getGauntletVersionIds", () => {
-    test("returns gauntlet versions associated with pantheon activities", () => {
-        expect(
-            getGauntletVersionIds(
-                [
-                    {
-                        id: 129,
-                        name: "Oryx Exalted",
-                        path: "oryx",
-                        associatedActivityId: 101,
-                        isChallengeMode: false
-                    },
-                    {
-                        id: 200,
-                        name: "Gauntlet Mode",
-                        path: GAUNTLET_VERSION_PATH,
-                        associatedActivityId: 102,
-                        isChallengeMode: false
-                    }
-                ],
-                [101, 102]
-            )
-        ).toEqual([200])
-    })
-})
+import { getPantheonActivityIds, sortPantheonActivityIds } from "@/services/manifest/pantheon"
+import { describe, expect, test } from "bun:test"
+
+const pantheonActivity = {
+    isRaid: false,
+    releaseDate: null,
+    dayOneEnd: null,
+    contestEnd: null,
+    weekOneEnd: null,
+    milestoneHash: null,
+    splashSlug: "pantheon"
+} as const
+
+describe("getPantheonActivityIds", () => {
+    test("returns activities with pantheon paths", () => {
+        expect(
+            getPantheonActivityIds([
+                {
+                    id: 9,
+                    name: "Vault of Glass",
+                    path: "vaultofglass",
+                    isSunset: false,
+                    isRaid: true,
+                    releaseDate: null,
+                    dayOneEnd: null,
+                    contestEnd: null,
+                    weekOneEnd: null,
+                    milestoneHash: null,
+                    splashSlug: "vog"
+                },
+                {
+                    id: 101,
+                    name: "The Pantheon",
+                    path: "thepantheon",
+                    isSunset: true,
+                    ...pantheonActivity
+                },
+                {
+                    id: 102,
+                    name: "Pantheon",
+                    path: "pantheon",
+                    isSunset: false,
+                    ...pantheonActivity
+                }
+            ])
+        ).toEqual([101, 102])
+    })
+})
+
+describe("sortPantheonActivityIds", () => {
+    test("lists active pantheon activities before sunset activities", () => {
+        expect(
+            sortPantheonActivityIds(
+                [
+                    {
+                        id: 101,
+                        name: "The Pantheon",
+                        path: "thepantheon",
+                        isSunset: true,
+                        ...pantheonActivity
+                    },
+                    {
+                        id: 102,
+                        name: "Pantheon",
+                        path: "pantheon",
+                        isSunset: false,
+                        ...pantheonActivity
+                    }
+                ],
+                [101, 102]
+            )
+        ).toEqual([102, 101])
+    })
+})

--- a/src/services/manifest/pantheon.ts
+++ b/src/services/manifest/pantheon.ts
@@ -1,48 +1,63 @@
-import { pgReader } from "@/integrations/postgres"
-import { ActivityDefinition } from "@/schema/components/ActivityDefinition"
-
-export const PANTHEON_ACTIVITY_PATH = "pantheon"
-export const PANTHEON_SUNSET_ACTIVITY_PATH = "thepantheon"
-export const PANTHEON_ACTIVITY_PATHS = [
-    PANTHEON_ACTIVITY_PATH,
-    PANTHEON_SUNSET_ACTIVITY_PATH
-] as const
-
-const isPantheonActivityPath = (path: string) =>
-    (PANTHEON_ACTIVITY_PATHS as readonly string[]).includes(path)
-
-export const getPantheonActivityIds = (activities: ActivityDefinition[]) =>
-    activities
-        .filter(activity => isPantheonActivityPath(activity.path))
-        .map(activity => activity.id)
-
-export const sortPantheonActivityIds = (
-    activities: ActivityDefinition[],
-    pantheonActivityIds: readonly number[]
-) => {
-    const activityById = new Map(activities.map(activity => [activity.id, activity]))
-
-    return [...pantheonActivityIds].sort((a, b) => {
-        const activityA = activityById.get(a)
-        const activityB = activityById.get(b)
-        if (!activityA || !activityB) {
-            return b - a
-        }
-        if (+activityA.isSunset ^ +activityB.isSunset) {
-            return activityA.isSunset ? 1 : -1
-        }
-        return b - a
-    })
-}
-
-export const getPantheonVersionId = async (versionPath: string) => {
-    return await pgReader.queryRow<{ id: number }>(
-        `SELECT vd.id::int
-         FROM version_definition vd
-         INNER JOIN activity_definition ad ON ad.id = vd.associated_activity_id
-         WHERE vd.path = $1 AND ad.path = ANY($2::text[])
-         ORDER BY ad.is_sunset ASC, ad.id DESC
-         LIMIT 1`,
-        { params: [versionPath, [...PANTHEON_ACTIVITY_PATHS]] }
-    )
-}
+import { pgReader } from "@/integrations/postgres"
+import { ActivityDefinition } from "@/schema/components/ActivityDefinition"
+import { VersionDefinition } from "@/schema/components/VersionDefinition"
+
+export const PANTHEON_ACTIVITY_PATH = "pantheon"
+export const PANTHEON_SUNSET_ACTIVITY_PATH = "thepantheon"
+export const GAUNTLET_VERSION_PATH = "gauntlet"
+export const PANTHEON_ACTIVITY_PATHS = [
+    PANTHEON_ACTIVITY_PATH,
+    PANTHEON_SUNSET_ACTIVITY_PATH
+] as const
+
+const isPantheonActivityPath = (path: string) =>
+    (PANTHEON_ACTIVITY_PATHS as readonly string[]).includes(path)
+
+export const getPantheonActivityIds = (activities: ActivityDefinition[]) =>
+    activities
+        .filter(activity => isPantheonActivityPath(activity.path))
+        .map(activity => activity.id)
+
+export const sortPantheonActivityIds = (
+    activities: ActivityDefinition[],
+    pantheonActivityIds: readonly number[]
+) => {
+    const activityById = new Map(activities.map(activity => [activity.id, activity]))
+
+    return [...pantheonActivityIds].sort((a, b) => {
+        const activityA = activityById.get(a)
+        const activityB = activityById.get(b)
+        if (!activityA || !activityB) {
+            return b - a
+        }
+        if (+activityA.isSunset ^ +activityB.isSunset) {
+            return activityA.isSunset ? 1 : -1
+        }
+        return b - a
+    })
+}
+
+export const getGauntletVersionIds = (
+    versions: VersionDefinition[],
+    pantheonActivityIds: readonly number[]
+) =>
+    versions
+        .filter(
+            version =>
+                version.path === GAUNTLET_VERSION_PATH &&
+                version.associatedActivityId !== null &&
+                pantheonActivityIds.includes(version.associatedActivityId)
+        )
+        .map(version => version.id)
+
+export const getPantheonVersionId = async (versionPath: string) => {
+    return await pgReader.queryRow<{ id: number }>(
+        `SELECT vd.id::int
+         FROM version_definition vd
+         INNER JOIN activity_definition ad ON ad.id = vd.associated_activity_id
+         WHERE vd.path = $1 AND ad.path = ANY($2::text[])
+         ORDER BY ad.is_sunset ASC, ad.id DESC
+         LIMIT 1`,
+        { params: [versionPath, [...PANTHEON_ACTIVITY_PATHS]] }
+    )
+}

--- a/src/services/manifest/pantheon.ts
+++ b/src/services/manifest/pantheon.ts
@@ -1,63 +1,48 @@
-import { pgReader } from "@/integrations/postgres"
-import { ActivityDefinition } from "@/schema/components/ActivityDefinition"
-import { VersionDefinition } from "@/schema/components/VersionDefinition"
-
-export const PANTHEON_ACTIVITY_PATH = "pantheon"
-export const PANTHEON_SUNSET_ACTIVITY_PATH = "thepantheon"
-export const GAUNTLET_VERSION_PATH = "gauntlet"
-export const PANTHEON_ACTIVITY_PATHS = [
-    PANTHEON_ACTIVITY_PATH,
-    PANTHEON_SUNSET_ACTIVITY_PATH
-] as const
-
-const isPantheonActivityPath = (path: string) =>
-    (PANTHEON_ACTIVITY_PATHS as readonly string[]).includes(path)
-
-export const getPantheonActivityIds = (activities: ActivityDefinition[]) =>
-    activities
-        .filter(activity => isPantheonActivityPath(activity.path))
-        .map(activity => activity.id)
-
-export const sortPantheonActivityIds = (
-    activities: ActivityDefinition[],
-    pantheonActivityIds: readonly number[]
-) => {
-    const activityById = new Map(activities.map(activity => [activity.id, activity]))
-
-    return [...pantheonActivityIds].sort((a, b) => {
-        const activityA = activityById.get(a)
-        const activityB = activityById.get(b)
-        if (!activityA || !activityB) {
-            return b - a
-        }
-        if (+activityA.isSunset ^ +activityB.isSunset) {
-            return activityA.isSunset ? 1 : -1
-        }
-        return b - a
-    })
-}
-
-export const getGauntletVersionIds = (
-    versions: VersionDefinition[],
-    pantheonActivityIds: readonly number[]
-) =>
-    versions
-        .filter(
-            version =>
-                version.path === GAUNTLET_VERSION_PATH &&
-                version.associatedActivityId !== null &&
-                pantheonActivityIds.includes(version.associatedActivityId)
-        )
-        .map(version => version.id)
-
-export const getPantheonVersionId = async (versionPath: string) => {
-    return await pgReader.queryRow<{ id: number }>(
-        `SELECT vd.id::int
-         FROM version_definition vd
-         INNER JOIN activity_definition ad ON ad.id = vd.associated_activity_id
-         WHERE vd.path = $1 AND ad.path = ANY($2::text[])
-         ORDER BY ad.is_sunset ASC, ad.id DESC
-         LIMIT 1`,
-        { params: [versionPath, [...PANTHEON_ACTIVITY_PATHS]] }
-    )
-}
+import { pgReader } from "@/integrations/postgres"
+import { ActivityDefinition } from "@/schema/components/ActivityDefinition"
+
+export const PANTHEON_ACTIVITY_PATH = "pantheon"
+export const PANTHEON_SUNSET_ACTIVITY_PATH = "thepantheon"
+export const PANTHEON_ACTIVITY_PATHS = [
+    PANTHEON_ACTIVITY_PATH,
+    PANTHEON_SUNSET_ACTIVITY_PATH
+] as const
+
+const isPantheonActivityPath = (path: string) =>
+    (PANTHEON_ACTIVITY_PATHS as readonly string[]).includes(path)
+
+export const getPantheonActivityIds = (activities: ActivityDefinition[]) =>
+    activities
+        .filter(activity => isPantheonActivityPath(activity.path))
+        .map(activity => activity.id)
+
+export const sortPantheonActivityIds = (
+    activities: ActivityDefinition[],
+    pantheonActivityIds: readonly number[]
+) => {
+    const activityById = new Map(activities.map(activity => [activity.id, activity]))
+
+    return [...pantheonActivityIds].sort((a, b) => {
+        const activityA = activityById.get(a)
+        const activityB = activityById.get(b)
+        if (!activityA || !activityB) {
+            return b - a
+        }
+        if (+activityA.isSunset ^ +activityB.isSunset) {
+            return activityA.isSunset ? 1 : -1
+        }
+        return b - a
+    })
+}
+
+export const getPantheonVersionId = async (versionPath: string) => {
+    return await pgReader.queryRow<{ id: number }>(
+        `SELECT vd.id::int
+         FROM version_definition vd
+         INNER JOIN activity_definition ad ON ad.id = vd.associated_activity_id
+         WHERE vd.path = $1 AND ad.path = ANY($2::text[])
+         ORDER BY ad.is_sunset ASC, ad.id DESC
+         LIMIT 1`,
+        { params: [versionPath, [...PANTHEON_ACTIVITY_PATHS]] }
+    )
+}

--- a/src/services/manifest/pantheon.ts
+++ b/src/services/manifest/pantheon.ts
@@ -1,12 +1,20 @@
 import { pgReader } from "@/integrations/postgres"
 import { ActivityDefinition } from "@/schema/components/ActivityDefinition"
-import { VersionDefinition } from "@/schema/components/VersionDefinition"
 
 export const PANTHEON_ACTIVITY_PATH = "pantheon"
-export const GAUNTLET_VERSION_PATH = "gauntlet"
+export const PANTHEON_SUNSET_ACTIVITY_PATH = "thepantheon"
+export const PANTHEON_ACTIVITY_PATHS = [
+    PANTHEON_ACTIVITY_PATH,
+    PANTHEON_SUNSET_ACTIVITY_PATH
+] as const
+
+const isPantheonActivityPath = (path: string) =>
+    (PANTHEON_ACTIVITY_PATHS as readonly string[]).includes(path)
 
 export const getPantheonActivityIds = (activities: ActivityDefinition[]) =>
-    activities.filter(activity => activity.path === PANTHEON_ACTIVITY_PATH).map(activity => activity.id)
+    activities
+        .filter(activity => isPantheonActivityPath(activity.path))
+        .map(activity => activity.id)
 
 export const sortPantheonActivityIds = (
     activities: ActivityDefinition[],
@@ -27,27 +35,14 @@ export const sortPantheonActivityIds = (
     })
 }
 
-export const getGauntletVersionIds = (
-    versions: VersionDefinition[],
-    pantheonActivityIds: readonly number[]
-) =>
-    versions
-        .filter(
-            version =>
-                version.path === GAUNTLET_VERSION_PATH &&
-                version.associatedActivityId !== null &&
-                pantheonActivityIds.includes(version.associatedActivityId)
-        )
-        .map(version => version.id)
-
 export const getPantheonVersionId = async (versionPath: string) => {
     return await pgReader.queryRow<{ id: number }>(
         `SELECT vd.id::int
          FROM version_definition vd
          INNER JOIN activity_definition ad ON ad.id = vd.associated_activity_id
-         WHERE vd.path = $1 AND ad.path = $2
+         WHERE vd.path = $1 AND ad.path = ANY($2::text[])
          ORDER BY ad.is_sunset ASC, ad.id DESC
          LIMIT 1`,
-        { params: [versionPath, PANTHEON_ACTIVITY_PATH] }
+        { params: [versionPath, [...PANTHEON_ACTIVITY_PATHS]] }
     )
 }

--- a/src/services/manifest/pantheon.ts
+++ b/src/services/manifest/pantheon.ts
@@ -1,8 +1,10 @@
 import { pgReader } from "@/integrations/postgres"
 import { ActivityDefinition } from "@/schema/components/ActivityDefinition"
+import { VersionDefinition } from "@/schema/components/VersionDefinition"
 
 export const PANTHEON_ACTIVITY_PATH = "pantheon"
 export const PANTHEON_SUNSET_ACTIVITY_PATH = "thepantheon"
+export const GAUNTLET_VERSION_PATH = "gauntlet"
 export const PANTHEON_ACTIVITY_PATHS = [
     PANTHEON_ACTIVITY_PATH,
     PANTHEON_SUNSET_ACTIVITY_PATH
@@ -34,6 +36,19 @@ export const sortPantheonActivityIds = (
         return b - a
     })
 }
+
+export const getGauntletVersionIds = (
+    versions: VersionDefinition[],
+    pantheonActivityIds: readonly number[]
+) =>
+    versions
+        .filter(
+            version =>
+                version.path === GAUNTLET_VERSION_PATH &&
+                version.associatedActivityId !== null &&
+                pantheonActivityIds.includes(version.associatedActivityId)
+        )
+        .map(version => version.id)
 
 export const getPantheonVersionId = async (versionPath: string) => {
     return await pgReader.queryRow<{ id: number }>(

--- a/src/services/manifest/pantheon.ts
+++ b/src/services/manifest/pantheon.ts
@@ -1,0 +1,53 @@
+import { pgReader } from "@/integrations/postgres"
+import { ActivityDefinition } from "@/schema/components/ActivityDefinition"
+import { VersionDefinition } from "@/schema/components/VersionDefinition"
+
+export const PANTHEON_ACTIVITY_PATH = "pantheon"
+export const GAUNTLET_VERSION_PATH = "gauntlet"
+
+export const getPantheonActivityIds = (activities: ActivityDefinition[]) =>
+    activities.filter(activity => activity.path === PANTHEON_ACTIVITY_PATH).map(activity => activity.id)
+
+export const sortPantheonActivityIds = (
+    activities: ActivityDefinition[],
+    pantheonActivityIds: readonly number[]
+) => {
+    const activityById = new Map(activities.map(activity => [activity.id, activity]))
+
+    return [...pantheonActivityIds].sort((a, b) => {
+        const activityA = activityById.get(a)
+        const activityB = activityById.get(b)
+        if (!activityA || !activityB) {
+            return b - a
+        }
+        if (+activityA.isSunset ^ +activityB.isSunset) {
+            return activityA.isSunset ? 1 : -1
+        }
+        return b - a
+    })
+}
+
+export const getGauntletVersionIds = (
+    versions: VersionDefinition[],
+    pantheonActivityIds: readonly number[]
+) =>
+    versions
+        .filter(
+            version =>
+                version.path === GAUNTLET_VERSION_PATH &&
+                version.associatedActivityId !== null &&
+                pantheonActivityIds.includes(version.associatedActivityId)
+        )
+        .map(version => version.id)
+
+export const getPantheonVersionId = async (versionPath: string) => {
+    return await pgReader.queryRow<{ id: number }>(
+        `SELECT vd.id::int
+         FROM version_definition vd
+         INNER JOIN activity_definition ad ON ad.id = vd.associated_activity_id
+         WHERE vd.path = $1 AND ad.path = $2
+         ORDER BY ad.is_sunset ASC, ad.id DESC
+         LIMIT 1`,
+        { params: [versionPath, PANTHEON_ACTIVITY_PATH] }
+    )
+}


### PR DESCRIPTION
## Summary

Pantheon 2.0 API support for dual activities and manifest-driven version lookup.

- **Activity 101** (`The Pantheon`, path `thepantheon`, sunset): EP boss versions 128–131
- **Activity 102** (`Pantheon`, path `pantheon`, permanent 9.7.0 return): versions 132 Calus, 133 Morgeth
- `getPantheonActivityIds` and `getPantheonVersionId` match both `pantheon` and `thepantheon` activity paths (active activity preferred when paths collide)
- Manifest exposes `pantheonIds`, `gauntletVersionIds` (infrastructure for gauntlet modes when present in DB — no hardcoded v134)
- Individual pantheon leaderboard routes resolve versions by path instead of hardcoded activity 101

## Deploy order

1. **Services** [#46](https://github.com/Raid-Hub/Services/pull/46) — schema migration + service code (no seed data in PR)
2. Run production data steps in `docs/pantheon-2.0-deploy-plan.md` (activity 101 sunset + `thepantheon` path, activity 102, versions 132–133, hash mappings)
3. Refresh `leaderboard.individual_pantheon_version_leaderboard`
4. **API** (this PR) — deploy after Services data is applied
5. **Website** [#324](https://github.com/Raid-Hub/Web-App/pull/324)

## Test plan

- [ ] `bun test src/services/manifest/pantheon.test.ts`
- [ ] `bun test src/routes/leaderboard/individual/pantheon.test.ts` (legacy versions; Calus/Morgeth need seeded DB)
- [ ] `bun run typecheck` and `bun format --check`
- [ ] `/manifest` returns `isSunset` for 101, active 102, and `gauntletVersionIds` when gauntlet versions exist
- [ ] Pantheon leaderboard endpoints for legacy paths (`atraks`, `oryx`, etc.) and new paths (`calus`, `morgeth`) after data deploy
- [ ] Unknown version paths return `PantheonVersionNotFound`