### PR TITLE
Hotfix: skull hash int overflow in difficulty tier query

### DIFF
--- a/src/services/difficulty-tier/resolve.ts
+++ b/src/services/difficulty-tier/resolve.ts
@@ -1,4 +1,5 @@
 import { pgReader } from "@/integrations/postgres"
+import { convertUInt32Value } from "@/integrations/postgres/transformer"
 import { DifficultyTier } from "@/schema/enums/DifficultyTier"
 import { activityHasTierCollection, classifyDifficultyTier } from "./classify"
 
@@ -11,10 +12,13 @@ async function loadKnownFeatSkulls(
     }
 
     const rows = await pgReader.queryRows<{ skullHash: number }>(
-        `SELECT skull_hash::int AS "skullHash"
+        `SELECT skull_hash AS "skullHash"
          FROM activity_feat_definition
          WHERE skull_hash = ANY($1::bigint[])`,
-        { params: [unique] }
+        {
+            params: [unique],
+            transformers: { skullHash: convertUInt32Value }
+        }
     )
 
     return new Set(rows.map(row => row.skullHash))


### PR DESCRIPTION
## Summary

Production error after Pantheon 2.0 deploy: `integer out of range` on `/player/*/history` and `/instance/*`.

`loadKnownFeatSkulls` cast `skull_hash::int`, but Destiny skull hashes are uint32 and many exceed signed int32 max (e.g. `3975235718` for Consecrated Mind). Any instance with those skulls in `skull_hashes` crashed the endpoint.

Fix: select `skull_hash` as bigint and use `convertUInt32Value`, matching `listFeatDefinitions`.

## Test plan

- [x] `bun test src/services/difficulty-tier/`
- [ ] Deploy and verify `/player/*/history` no longer 500s for pantheon players

Made with [Cursor](https://cursor.com)