### PR TITLE
Hotfix: redeploy difficulty tier skull hash fix

### DIFF
--- a/src/services/difficulty-tier/resolve.test.ts
+++ b/src/services/difficulty-tier/resolve.test.ts
@@ -1,0 +1,36 @@
+import { pgReader } from "@/integrations/postgres"
+import { convertUInt32Value } from "@/integrations/postgres/transformer"
+import { describe, expect, it } from "bun:test"
+import { attachDifficultyTiers } from "./resolve"
+
+// Consecrated Mind pantheon hash — above signed int32 max (2_147_483_647).
+const UINT32_ABOVE_INT32 = 3975235718
+const EMPTY_FEAT = 790421403
+
+describe("difficulty tier feat skull lookup", () => {
+    it("queries skull_hash as bigint without int cast overflow", async () => {
+        const rows = await pgReader.queryRows<{ skullHash: number }>(
+            `SELECT skull_hash AS "skullHash"
+             FROM activity_feat_definition
+             WHERE skull_hash = ANY($1::bigint[])`,
+            {
+                params: [[UINT32_ABOVE_INT32, EMPTY_FEAT].map(skull => BigInt(skull))],
+                transformers: { skullHash: convertUInt32Value }
+            }
+        )
+
+        expect(Array.isArray(rows)).toBe(true)
+    })
+
+    it("attachDifficultyTiers handles uint32 skull hashes above int32 max", async () => {
+        const result = await attachDifficultyTiers([
+            {
+                skullHashes: [EMPTY_FEAT, UINT32_ABOVE_INT32],
+                activityId: 102
+            }
+        ])
+
+        expect(result).toHaveLength(1)
+        expect(result[0].difficultyTier).not.toBeNull()
+    })
+})

--- a/src/services/difficulty-tier/resolve.ts
+++ b/src/services/difficulty-tier/resolve.ts
@@ -16,7 +16,7 @@ async function loadKnownFeatSkulls(
          FROM activity_feat_definition
          WHERE skull_hash = ANY($1::bigint[])`,
         {
-            params: [unique],
+            params: [unique.map(skull => BigInt(skull))],
             transformers: { skullHash: convertUInt32Value }
         }
     )


### PR DESCRIPTION
## Summary

Production Sentry still shows the **old** query (`skull_hash::int`) after #134 merged — the API process from the 03:24 Pantheon deploy was not restarted when #134 deployed at 03:30 (`app_start_time` unchanged).

This PR:
- Confirms the #134 fix (no `::int` cast, `convertUInt32Value` transformer)
- Passes `bigint[]` bind params for skull hash lookups
- Adds regression tests for skull values above int32 max (e.g. `3975235718`)

Merging triggers a fresh prod deploy.

## Test plan

- [x] `bun test src/services/difficulty-tier/`

Made with [Cursor](https://cursor.com)