### PR TITLE
Fix admin blacklist insert BlacklistReportSource cast

### DIFF
--- a/src/services/reporting/update-blacklist.ts
+++ b/src/services/reporting/update-blacklist.ts
@@ -13,15 +13,15 @@ export const blacklistInstance = async (data: {
         // Insert into blacklist_instance
         const reportSource = data.reportId ? "WebReport" : "Manual"
         await conn.queryRow(
-            `INSERT INTO blacklist_instance (instance_id, report_source, report_id, reason)
-            VALUES ($1::bigint, $2::"BlacklistReportSource", $3, $4)
+            `INSERT INTO flagging.blacklist_instance (instance_id, report_source, report_id, reason)
+            VALUES ($1::bigint, $2, $3, $4)
             ON CONFLICT (instance_id) DO NOTHING`,
             { params: [data.instanceId, reportSource, data.reportId, data.reason] }
         )
 
         // Insert into blacklist_instance_flag
         const playerStmnt = await conn.prepare(
-            `INSERT INTO blacklist_instance_player (instance_id, membership_id, reason)
+            `INSERT INTO flagging.blacklist_instance_player (instance_id, membership_id, reason)
             VALUES ($1::bigint, $2::bigint, $3)
             ON CONFLICT (instance_id, membership_id) DO NOTHING`
         )
@@ -43,9 +43,12 @@ export const blacklistInstance = async (data: {
 export const removeInstanceBlacklist = async (instanceId: bigint | string) => {
     return await pgAdmin.transaction(async conn => {
         // Delete from blacklist_instance
-        await conn.queryRow(`DELETE FROM blacklist_instance WHERE instance_id = $1::bigint`, {
-            params: [instanceId]
-        })
+        await conn.queryRow(
+            `DELETE FROM flagging.blacklist_instance WHERE instance_id = $1::bigint`,
+            {
+                params: [instanceId]
+            }
+        )
 
         // Set instance.is_whitelisted to true
         await conn.queryRow(


### PR DESCRIPTION
## Summary

- Fixes `PUT /admin/reporting/blacklist/:instanceId` failing with `type "BlacklistReportSource" does not exist` in production
- Removes the unqualified `::"BlacklistReportSource"` cast and lets Postgres coerce `report_source` from the column type
- Schema-qualifies blacklist writes to `flagging.blacklist_instance` and `flagging.blacklist_instance_player`

Fixes https://raidhub.sentry.io/issues/7548840538/

## Test plan

- [x] ESLint passes (pre-commit hook)
- [ ] CI test workflow passes
- [ ] Verify `PUT /admin/reporting/blacklist/:instanceId` succeeds in production after deploy


Made with [Cursor](https://cursor.com)