### PR TITLE
Fix parsing of the comma-separated `membershipIds` query param

### DIFF
--- a/src/routes/player/membershipId/instances.ts
+++ b/src/routes/player/membershipId/instances.ts
@@ -23,7 +23,9 @@ export const playerInstancesRoute = new RaidHubRoute({
         membershipId: zBigIntString()
     }),
     query: z.object({
-        membershipIds: zSplitCommaSeparatedString(zBigIntString(), a => a.max(6).default([])).openapi({
+        membershipIds: zSplitCommaSeparatedString(zBigIntString(), a =>
+            a.max(6).default([])
+        ).openapi({
             description:
                 "A comma-separated list of up to 6 membershipIds the must be present in the instance. You do not need to include the target membershipId from the path parameter in this list."
         }),

--- a/src/routes/player/membershipId/instances.ts
+++ b/src/routes/player/membershipId/instances.ts
@@ -23,7 +23,7 @@ export const playerInstancesRoute = new RaidHubRoute({
         membershipId: zBigIntString()
     }),
     query: z.object({
-        membershipIds: zSplitCommaSeparatedString(zBigIntString()).max(6).default([]).openapi({
+        membershipIds: zSplitCommaSeparatedString(zBigIntString(), a => a.max(6).default([])).openapi({
             description:
                 "A comma-separated list of up to 6 membershipIds the must be present in the instance. You do not need to include the target membershipId from the path parameter in this list."
         }),

--- a/src/schema/input.test.ts
+++ b/src/schema/input.test.ts
@@ -1,6 +1,7 @@
 import "@/schema/registry" // Initialize OpenAPI extensions
 import { describe, expect, test } from "bun:test"
-import { zBoolString } from "./input"
+import { z } from "zod"
+import { zBigIntString, zBoolString, zSplitCommaSeparatedString } from "./input"
 
 describe("zBoolString", () => {
     test("should parse truthy values correctly", () => {
@@ -37,5 +38,157 @@ describe("zBoolString", () => {
             const result = schema.safeParse(value)
             expect(result.success).toBe(false)
         })
+    })
+})
+
+describe("zSplitCommaSeparatedString", () => {
+    test("should fail on non-string non-array input", () => {
+        const schema = zSplitCommaSeparatedString(z.any())
+        const nonStringValues = [
+            123,
+            1234567890123456789012345678901234567890123456789012345678901234567890n,
+            0,
+            NaN,
+            {},
+            null,
+            undefined
+        ]
+
+        nonStringValues.forEach(value => {
+            const result = schema.safeParse(value)
+            expect(result.success).toBe(false)
+        })
+    })
+
+    test("should coerce empty string to an array with one empty string element", () => {
+        const schema = zSplitCommaSeparatedString(z.any())
+        const inputValue = ""
+
+        const result = schema.safeParse(inputValue)
+        expect(result.success).toBe(true)
+        if (result.success) {
+            expect(result.data).toEqual([""])
+        }
+    })
+
+    test("should split comma-separated values", () => {
+        const schema = zSplitCommaSeparatedString(z.any())
+        const inputValue = "qwe,123,null,NaN,undefined"
+
+        const result = schema.safeParse(inputValue)
+        expect(result.success).toBe(true)
+        if (result.success) {
+            expect(result.data).toEqual(["qwe", "123", "null", "NaN", "undefined"])
+        }
+    })
+
+    test("should fail on elements not passing the array-item schema", () => {
+        const schema = zSplitCommaSeparatedString(zBigIntString())
+        const nonconformingInputs = ["", "nah", ",", "123,", "123123123,notanumber"]
+
+        nonconformingInputs.forEach(value => {
+            const result = schema.safeParse(value)
+            expect(result.success).toBe(false)
+        })
+    })
+
+    test("should pass on a valid single-value input", () => {
+        const schema = zSplitCommaSeparatedString(zBigIntString())
+        const singleValueInput = [
+            { input: "123", expected: [123n] },
+            {
+                input: "1234567890123456789012345678901234567890123456789012345678901234567890",
+                expected: [1234567890123456789012345678901234567890123456789012345678901234567890n]
+            }
+        ]
+
+        singleValueInput.forEach(value => {
+            const result = schema.safeParse(value.input)
+            expect(result.success).toBe(true)
+            if (result.success) {
+                expect(result.data).toEqual(value.expected)
+            }
+        })
+    })
+
+    test("should pass on a valid multi-value input", () => {
+        const schema = zSplitCommaSeparatedString(zBigIntString())
+        const singleValueInput = [
+            { input: "123,123,123", expected: [123n, 123n, 123n] },
+            {
+                input: "123,1234567890123456789012345678901234567890123456789012345678901234567890",
+                expected: [
+                    123n,
+                    1234567890123456789012345678901234567890123456789012345678901234567890n
+                ]
+            },
+            {
+                input: "11234567890123456789012345678901234567890123456789012345678901234567890,21234567890123456789012345678901234567890123456789012345678901234567890,31234567890123456789012345678901234567890123456789012345678901234567890",
+                expected: [
+                    1_1234567890123456789012345678901234567890123456789012345678901234567890n,
+                    2_1234567890123456789012345678901234567890123456789012345678901234567890n,
+                    3_1234567890123456789012345678901234567890123456789012345678901234567890n
+                ]
+            }
+        ]
+
+        singleValueInput.forEach(value => {
+            const result = schema.safeParse(value.input)
+            expect(result.success).toBe(true)
+            if (result.success) {
+                expect(result.data).toEqual(value.expected)
+            }
+        })
+    })
+
+    test("should not fail parsing on excessive spaces", () => {
+        const schema = zSplitCommaSeparatedString(zBigIntString())
+        const validValuesWithExtraSpaces = [
+            { input: " 123", expected: [123n] },
+            { input: "123 ", expected: [123n] },
+            { input: " 123 ", expected: [123n] },
+            {
+                input: " 1234567890123456789012345678901234567890123456789012345678901234567890",
+                expected: [1234567890123456789012345678901234567890123456789012345678901234567890n]
+            },
+            {
+                input: "1234567890123456789012345678901234567890123456789012345678901234567890 ",
+                expected: [1234567890123456789012345678901234567890123456789012345678901234567890n]
+            },
+            {
+                input: " 1234567890123456789012345678901234567890123456789012345678901234567890 ",
+                expected: [1234567890123456789012345678901234567890123456789012345678901234567890n]
+            },
+            {
+                input: "  123  ,  1234567890123456789012345678901234567890123456789012345678901234567890  ",
+                expected: [
+                    123n,
+                    1234567890123456789012345678901234567890123456789012345678901234567890n
+                ]
+            }
+        ]
+
+        validValuesWithExtraSpaces.forEach(value => {
+            const result = schema.safeParse(value.input)
+            expect(result.success).toBe(true)
+            if (result.success) {
+                expect(result.data).toEqual(value.expected)
+            }
+        })
+    })
+
+    test("should pass an input array, but still checks the items", () => {
+        const schema = zSplitCommaSeparatedString(zBigIntString())
+        const invalidArrayInput = [123123n, "qweqwe"]
+        const validArrayInput = [123, 123123]
+
+        const invalidResult = schema.safeParse(invalidArrayInput)
+        expect(invalidResult.success).toBe(false)
+
+        const validResult = schema.safeParse(validArrayInput)
+        expect(validResult.success).toBe(true)
+        if (validResult.success) {
+            expect(validResult.data).toEqual([123n, 123123n])
+        }
     })
 })

--- a/src/schema/input.ts
+++ b/src/schema/input.ts
@@ -44,12 +44,18 @@ export const zDigitString = () =>
 // Input param that will be coerced to a BigInt
 export const zBigIntString = () => zDigitString().transform(val => BigInt(val))
 
-export const zSplitCommaSeparatedString = <T extends ZodTypeAny>(schema: T) =>
-    z.array(
-        z.preprocess(val => {
-            if (typeof val === "string") {
-                return val.split(",")
-            }
-            return val
-        }, schema)
-    )
+export const zSplitCommaSeparatedString = <T extends ZodTypeAny, ResultingArray extends ZodTypeAny>(
+    itemSchema: T,
+    extendArraySchema?: (arraySchema: z.ZodArray<T>) => ResultingArray
+) => {
+    const finalArraySchema = extendArraySchema
+        ? extendArraySchema(z.array(itemSchema))
+        : z.array(itemSchema)
+
+    return z.preprocess(val => {
+        if (typeof val === "string") {
+            return val.split(",").map(s => s.trim())
+        }
+        return val
+    }, finalArraySchema)
+}


### PR DESCRIPTION
## Summary

Fixes Instance Finder failing when `membershipIds` is passed as a comma-separated query string (e.g. `/player/{id}/instances?membershipIds=123,456`).

This supersedes #131 by @lildeadprince with the same core fix plus CI fixes:
- Correct `zSplitCommaSeparatedString` so `z.preprocess` wraps the array schema (not the other way around)
- Trim whitespace around comma-separated values
- Add test coverage for `zSplitCommaSeparatedString`
- Fix Prettier formatting (CRLF → LF in test file)
- Move OpenAPI `.openapi()` metadata to the outer preprocess schema so docs stay accurate

Closes #131

## Test plan
- [x] `bun format --check`
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun docs` + openapi diff check
- [x] `bun test src/schema/input.test.ts` (11 tests pass)


Made with [Cursor](https://cursor.com)