### PR TITLE
Fix Sentry sourcemap build in deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
               run: bun install --frozen-lockfile
 
             - name: Build with sourcemaps
-              run: bun build --sourcemap=external ./src/index.ts --outfile ./dist/index.js
+              run: bun build --target=bun --sourcemap=external ./src/index.ts --outdir ./dist
 
             - name: Upload sourcemaps to Sentry
               env:
@@ -26,8 +26,8 @@ jobs:
                   SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
                   SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
               run: |
-                  npx @sentry/cli sourcemaps inject ./dist
-                  npx @sentry/cli sourcemaps upload --release=${{ github.sha }} ./dist
+                  bunx @sentry/cli sourcemaps inject ./dist
+                  bunx @sentry/cli sourcemaps upload --release=${{ github.sha }} ./dist
 
             - name: Install cloudflared
               run: ./.github/scripts/install-cloudflared.sh

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -16,7 +16,7 @@ jobs:
               run: bun install --frozen-lockfile
 
             - name: Build with sourcemaps
-              run: bun build --sourcemap=external ./src/index.ts --outfile ./dist/index.js
+              run: bun build --target=bun --sourcemap=external ./src/index.ts --outdir ./dist
 
             - name: Upload sourcemaps to Sentry
               env:
@@ -24,8 +24,8 @@ jobs:
                   SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
                   SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
               run: |
-                  npx @sentry/cli sourcemaps inject ./dist
-                  npx @sentry/cli sourcemaps upload --release=${{ github.sha }} ./dist
+                  bunx @sentry/cli sourcemaps inject ./dist
+                  bunx @sentry/cli sourcemaps upload --release=${{ github.sha }} ./dist
 
             - name: Install cloudflared
               run: ./.github/scripts/install-cloudflared.sh


### PR DESCRIPTION
## Summary
- Fix `bun build` failing with external sourcemaps by using `--outdir` and `--target=bun` instead of `--outfile`
- Run Sentry CLI via `bunx` instead of `npx` to match the Bun-based CI setup

## Test plan
- [x] `bun build --target=bun --sourcemap=external ./src/index.ts --outdir ./dist` succeeds locally
- [x] `bunx @sentry/cli sourcemaps inject ./dist` succeeds locally
- [ ] Deploy workflow passes on merge


Made with [Cursor](https://cursor.com)