### PR TITLE
Document pantheon2 splash slug for activity 102

### DIFF
--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -1409,7 +1409,7 @@
             "contestEnd": null,
             "weekOneEnd": null,
             "milestoneHash": null,
-            "splashSlug": "pantheon"
+            "splashSlug": "pantheon2"
           }
         ]
       },

--- a/src/schema/components/ActivityDefinition.ts
+++ b/src/schema/components/ActivityDefinition.ts
@@ -60,7 +60,7 @@ export const zActivityDefinition = registry.register(
                     contestEnd: null,
                     weekOneEnd: null,
                     milestoneHash: null,
-                    splashSlug: "pantheon"
+                    splashSlug: "pantheon2"
                 }
             ]
         })


### PR DESCRIPTION
## Summary
- Set OpenAPI example `splashSlug` for Pantheon: Monument of Triumph to `pantheon2`

## Test plan
- [ ] Manifest maps activity 102 to `content/splash/pantheon2/` after prod DB update


Made with [Cursor](https://cursor.com)