### PR TITLE
Fix community race leaderboard showing DNF players

### DIFF
--- a/src/services/leaderboard/team/custom.ts
+++ b/src/services/leaderboard/team/custom.ts
@@ -21,7 +21,7 @@ export const getPantheonCustomRaceTeamLeaderboard = async ({
             "lateral".players
         FROM team_pantheon_custom_race_leaderboard
         LEFT JOIN LATERAL (
-            SELECT
+            SELECT 
                 JSONB_AGG(
                     JSONB_BUILD_OBJECT(
                         'membershipId', membership_id::text,
@@ -34,7 +34,6 @@ export const getPantheonCustomRaceTeamLeaderboard = async ({
                         'isPrivate', is_private,
                         'cheatLevel', cheat_level
                     )
-                    ORDER BY instance_player.kills DESC
                 ) as "players"
             FROM instance_player
             INNER JOIN player USING (membership_id)

--- a/src/services/leaderboard/team/custom.ts
+++ b/src/services/leaderboard/team/custom.ts
@@ -34,11 +34,12 @@ export const getPantheonCustomRaceTeamLeaderboard = async ({
                         'isPrivate', is_private,
                         'cheatLevel', cheat_level
                     )
-                    ORDER BY instance_player.completed DESC, instance_player.time_played_seconds DESC
+                    ORDER BY instance_player.kills DESC
                 ) as "players"
             FROM instance_player
             INNER JOIN player USING (membership_id)
             WHERE instance_player.instance_id = team_pantheon_custom_race_leaderboard.instance_id
+                AND instance_player.completed
         ) as "lateral" ON true
         WHERE position > $1 AND position <= ($1 + $2)
         ORDER BY position ASC`,


### PR DESCRIPTION
## Summary
- Filter the pantheon community race team leaderboard player query to completed `instance_player` rows only, matching contest/first team leaderboards
- No player ordering (same as other team leaderboards)

Companion PR: Raid-Hub/Services#60 (materialized view + post-merge SQL)

## Test plan
- [ ] Open `/leaderboard/team/custom/pantheon-community-race` and confirm cleared runs no longer show DNF players

## Deploy notes
Deploying this API change fixes the displayed player list immediately. Run the post-merge SQL from the Services PR to keep search (`membership_ids`) in sync.