### PR TITLE
Restore checkpointNames on manifest for lowman tag labels

### DIFF
--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -2333,6 +2333,13 @@
               }
             },
             "description": "The mapping of each RaidHub versionId to its splash image URLs"
+          },
+          "checkpointNames": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "The checkpoint encounter name for each raid activityId, used in lowman tag labels"
           }
         },
         "required": [
@@ -2353,7 +2360,8 @@
           "rankingTiers",
           "feats",
           "splashUrls",
-          "versionSplashUrls"
+          "versionSplashUrls",
+          "checkpointNames"
         ],
         "additionalProperties": false
       },

--- a/src/routes/manifest.ts
+++ b/src/routes/manifest.ts
@@ -124,12 +124,10 @@ export const manifestRoute = new RaidHubRoute({
                             description:
                                 "The mapping of each RaidHub versionId to its splash image URLs"
                         }),
-                    checkpointNames: z
-                        .record(zNumericalRecordKey(), z.string())
-                        .openapi({
-                            description:
-                                "The checkpoint encounter name for each raid activityId, used in lowman tag labels"
-                        })
+                    checkpointNames: z.record(zNumericalRecordKey(), z.string()).openapi({
+                        description:
+                            "The checkpoint encounter name for each raid activityId, used in lowman tag labels"
+                    })
                 })
                 .strict()
         }

--- a/src/routes/manifest.ts
+++ b/src/routes/manifest.ts
@@ -5,6 +5,7 @@ import { zFeatDefinition } from "@/schema/components/FeatDefinition"
 import { zImageContentData } from "@/schema/components/ImageContentData"
 import { zVersionDefinition } from "@/schema/components/VersionDefinition"
 import { zNaturalNumber, zNumericalRecordKey } from "@/schema/output"
+import { getCheckpointNamesForRaids } from "@/services/manifest/checkpoint-names"
 import {
     listActivityDefinitions,
     listFeatDefinitions,
@@ -122,6 +123,12 @@ export const manifestRoute = new RaidHubRoute({
                         .openapi({
                             description:
                                 "The mapping of each RaidHub versionId to its splash image URLs"
+                        }),
+                    checkpointNames: z
+                        .record(zNumericalRecordKey(), z.string())
+                        .openapi({
+                            description:
+                                "The checkpoint encounter name for each raid activityId, used in lowman tag labels"
                         })
                 })
                 .strict()
@@ -158,6 +165,16 @@ export const manifestRoute = new RaidHubRoute({
             versionsForActivity[parseInt(activityId)] = [...set]
         })
 
+        const listedRaidIds = raids
+            .sort((a, b) => {
+                if (+a.isSunset ^ +b.isSunset) {
+                    return a.isSunset ? 1 : -1
+                } else {
+                    return b.id - a.id
+                }
+            })
+            .map(a => a.id)
+
         return RaidHubRoute.ok({
             hashes: Object.fromEntries(
                 hashes.map(h => [
@@ -170,15 +187,7 @@ export const manifestRoute = new RaidHubRoute({
             ),
             activityDefinitions: Object.fromEntries(activities.map(data => [data.id, data])),
             versionDefinitions: Object.fromEntries(versions.map(data => [data.id, data])),
-            listedRaidIds: raids
-                .sort((a, b) => {
-                    if (+a.isSunset ^ +b.isSunset) {
-                        return a.isSunset ? 1 : -1
-                    } else {
-                        return b.id - a.id
-                    }
-                })
-                .map(a => a.id),
+            listedRaidIds,
             sunsetRaidIds: raids.filter(a => a.isSunset).map(a => a.id),
             prestigeRaidIds: [
                 ...new Set(hashes.filter(h => h.versionId === 3).map(h => h.activityId))
@@ -198,7 +207,8 @@ export const manifestRoute = new RaidHubRoute({
             rankingTiers: TierBreaks,
             feats: feats,
             splashUrls: splashUrls,
-            versionSplashUrls: versionSplashUrls
+            versionSplashUrls: versionSplashUrls,
+            checkpointNames: getCheckpointNamesForRaids(listedRaidIds)
         })
     }
 })

--- a/src/services/manifest/checkpoint-names.ts
+++ b/src/services/manifest/checkpoint-names.ts
@@ -1,0 +1,26 @@
+/** Checkpoint encounter names for lowman tag labels. TODO: move to activity_definition. */
+export const CHECKPOINT_NAMES: Readonly<Record<number, string>> = {
+    1: "Calus",
+    2: "Argos",
+    3: "Val Ca'uor",
+    4: "Queenswalk",
+    5: "Insurrection Prime",
+    6: "Gahlran",
+    7: "Sanctified Mind",
+    8: "Taniks",
+    9: "Atheon",
+    10: "Rhulk",
+    11: "Oryx",
+    12: "Nezarec",
+    13: "Crota",
+    14: "Witness",
+    15: "Koregos",
+    16: "Koregos"
+}
+
+export const getCheckpointNamesForRaids = (listedRaidIds: readonly number[]) =>
+    Object.fromEntries(
+        listedRaidIds
+            .map(id => [id, CHECKPOINT_NAMES[id]] as const)
+            .filter((entry): entry is [number, string] => entry[1] != null)
+    )


### PR DESCRIPTION
## Summary
- Re-add `checkpointNames` to the `/manifest` response with per-raid boss encounter names (e.g. Witness, Oryx, Rhulk)
- Fixes profile raid tags showing generic "Checkpoint" instead of boss-specific labels like "Solo Witness"

## Test plan
- [x] Manifest route test passes locally
- [ ] Verify `/manifest` includes `checkpointNames` with expected boss names after deploy


Made with [Cursor](https://cursor.com)