### PR TITLE
Fix Sentry API input validation and blacklist enum cast

### DIFF
--- a/open-api/openapi.json
+++ b/open-api/openapi.json
@@ -5181,7 +5181,8 @@
             "schema": {
               "type": "integer",
               "nullable": true,
-              "minimum": 0
+              "minimum": 0,
+              "maximum": 2147483647
             },
             "required": false,
             "name": "minDurationSeconds",
@@ -5191,7 +5192,8 @@
             "schema": {
               "type": "integer",
               "nullable": true,
-              "minimum": 0
+              "minimum": 0,
+              "maximum": 2147483647
             },
             "required": false,
             "name": "maxDurationSeconds",

--- a/src/routes/player/membershipId/instances.ts
+++ b/src/routes/player/membershipId/instances.ts
@@ -6,8 +6,8 @@ import {
     zBigIntString,
     zBoolString,
     zCoercedNaturalNumber,
-    zPgInt32,
     zDateString,
+    zPgInt32,
     zSplitCommaSeparatedString
 } from "@/schema/input"
 import { zInt64 } from "@/schema/output"

--- a/src/routes/player/membershipId/instances.ts
+++ b/src/routes/player/membershipId/instances.ts
@@ -6,7 +6,7 @@ import {
     zBigIntString,
     zBoolString,
     zCoercedNaturalNumber,
-    zCoercedWholeNumber,
+    zPgInt32,
     zDateString,
     zSplitCommaSeparatedString
 } from "@/schema/input"
@@ -37,8 +37,8 @@ export const playerInstancesRoute = new RaidHubRoute({
         playerCount: zCoercedNaturalNumber().optional(),
         minPlayerCount: zCoercedNaturalNumber().optional(),
         maxPlayerCount: zCoercedNaturalNumber().optional(),
-        minDurationSeconds: zCoercedWholeNumber().optional(),
-        maxDurationSeconds: zCoercedWholeNumber().optional(),
+        minDurationSeconds: zPgInt32().optional(),
+        maxDurationSeconds: zPgInt32().optional(),
         season: zCoercedNaturalNumber().optional(),
         minSeason: zCoercedNaturalNumber().optional(),
         maxSeason: zCoercedNaturalNumber().optional(),

--- a/src/schema/input.test.ts
+++ b/src/schema/input.test.ts
@@ -1,7 +1,13 @@
 import "@/schema/registry" // Initialize OpenAPI extensions
 import { describe, expect, test } from "bun:test"
 import { z } from "zod"
-import { zBigIntString, zBoolString, zPgInt32, zSplitCommaSeparatedString, PG_BIGINT_MAX } from "./input"
+import {
+    PG_BIGINT_MAX,
+    zBigIntString,
+    zBoolString,
+    zPgInt32,
+    zSplitCommaSeparatedString
+} from "./input"
 
 describe("zBoolString", () => {
     test("should parse truthy values correctly", () => {
@@ -161,7 +167,7 @@ describe("zSplitCommaSeparatedString", () => {
             {
                 input: String(PG_BIGINT_MAX),
                 expected: [PG_BIGINT_MAX]
-            },
+            }
         ]
 
         validValuesWithExtraSpaces.forEach(value => {

--- a/src/schema/input.test.ts
+++ b/src/schema/input.test.ts
@@ -1,7 +1,7 @@
 import "@/schema/registry" // Initialize OpenAPI extensions
 import { describe, expect, test } from "bun:test"
 import { z } from "zod"
-import { zBigIntString, zBoolString, zSplitCommaSeparatedString } from "./input"
+import { zBigIntString, zBoolString, zPgInt32, zSplitCommaSeparatedString, PG_BIGINT_MAX } from "./input"
 
 describe("zBoolString", () => {
     test("should parse truthy values correctly", () => {
@@ -38,6 +38,20 @@ describe("zBoolString", () => {
             const result = schema.safeParse(value)
             expect(result.success).toBe(false)
         })
+    })
+})
+
+describe("zPgInt32", () => {
+    test("accepts values within PostgreSQL INTEGER range", () => {
+        const schema = zPgInt32()
+        expect(schema.safeParse(0).success).toBe(true)
+        expect(schema.safeParse(2_147_483_647).success).toBe(true)
+    })
+
+    test("rejects values above PostgreSQL INTEGER max", () => {
+        const schema = zPgInt32()
+        expect(schema.safeParse(10_000_000_000).success).toBe(false)
+        expect(schema.safeParse(2_147_483_648).success).toBe(false)
     })
 })
 
@@ -97,8 +111,8 @@ describe("zSplitCommaSeparatedString", () => {
         const singleValueInput = [
             { input: "123", expected: [123n] },
             {
-                input: "1234567890123456789012345678901234567890123456789012345678901234567890",
-                expected: [1234567890123456789012345678901234567890123456789012345678901234567890n]
+                input: String(PG_BIGINT_MAX),
+                expected: [PG_BIGINT_MAX]
             }
         ]
 
@@ -111,24 +125,21 @@ describe("zSplitCommaSeparatedString", () => {
         })
     })
 
+    test("should reject bigint values above PostgreSQL BIGINT max", () => {
+        const schema = zBigIntString()
+        const tooLarge = String(PG_BIGINT_MAX + 1n)
+
+        expect(schema.safeParse(tooLarge).success).toBe(false)
+        expect(schema.safeParse("46116860184306851060").success).toBe(false)
+    })
+
     test("should pass on a valid multi-value input", () => {
         const schema = zSplitCommaSeparatedString(zBigIntString())
         const singleValueInput = [
             { input: "123,123,123", expected: [123n, 123n, 123n] },
             {
-                input: "123,1234567890123456789012345678901234567890123456789012345678901234567890",
-                expected: [
-                    123n,
-                    1234567890123456789012345678901234567890123456789012345678901234567890n
-                ]
-            },
-            {
-                input: "11234567890123456789012345678901234567890123456789012345678901234567890,21234567890123456789012345678901234567890123456789012345678901234567890,31234567890123456789012345678901234567890123456789012345678901234567890",
-                expected: [
-                    1_1234567890123456789012345678901234567890123456789012345678901234567890n,
-                    2_1234567890123456789012345678901234567890123456789012345678901234567890n,
-                    3_1234567890123456789012345678901234567890123456789012345678901234567890n
-                ]
+                input: `123,${PG_BIGINT_MAX}`,
+                expected: [123n, PG_BIGINT_MAX]
             }
         ]
 
@@ -148,24 +159,9 @@ describe("zSplitCommaSeparatedString", () => {
             { input: "123 ", expected: [123n] },
             { input: " 123 ", expected: [123n] },
             {
-                input: " 1234567890123456789012345678901234567890123456789012345678901234567890",
-                expected: [1234567890123456789012345678901234567890123456789012345678901234567890n]
+                input: String(PG_BIGINT_MAX),
+                expected: [PG_BIGINT_MAX]
             },
-            {
-                input: "1234567890123456789012345678901234567890123456789012345678901234567890 ",
-                expected: [1234567890123456789012345678901234567890123456789012345678901234567890n]
-            },
-            {
-                input: " 1234567890123456789012345678901234567890123456789012345678901234567890 ",
-                expected: [1234567890123456789012345678901234567890123456789012345678901234567890n]
-            },
-            {
-                input: "  123  ,  1234567890123456789012345678901234567890123456789012345678901234567890  ",
-                expected: [
-                    123n,
-                    1234567890123456789012345678901234567890123456789012345678901234567890n
-                ]
-            }
         ]
 
         validValuesWithExtraSpaces.forEach(value => {
@@ -190,5 +186,19 @@ describe("zSplitCommaSeparatedString", () => {
         if (validResult.success) {
             expect(validResult.data).toEqual([123n, 123123n])
         }
+    })
+})
+
+describe("zPgInt32", () => {
+    test("accepts values within PostgreSQL INTEGER range", () => {
+        const schema = zPgInt32()
+        expect(schema.safeParse(0).success).toBe(true)
+        expect(schema.safeParse(2_147_483_647).success).toBe(true)
+    })
+
+    test("rejects values above PostgreSQL INTEGER max", () => {
+        const schema = zPgInt32()
+        expect(schema.safeParse(10_000_000_000).success).toBe(false)
+        expect(schema.safeParse(2_147_483_648).success).toBe(false)
     })
 })

--- a/src/schema/input.ts
+++ b/src/schema/input.ts
@@ -2,9 +2,21 @@ import { ZodBooleanDef, ZodDateDef, ZodNullable, ZodStringDef, ZodType, ZodTypeA
 
 // ===== INPUT SCHEMAS (for parsing/coercing user input) =====
 
+/** PostgreSQL signed BIGINT upper bound (membership_id, instance_id, etc.). */
+export const PG_BIGINT_MAX = 9223372036854775807n
+
+/** PostgreSQL INTEGER upper bound (duration, season_id, etc.). */
+export const PG_INT32_MAX = 2_147_483_647
+
 export const zCoercedNaturalNumber = () => z.coerce.number().int().positive()
 
 export const zCoercedWholeNumber = () => z.coerce.number().int().nonnegative()
+
+/** Whole number that fits in a PostgreSQL INTEGER column. */
+export const zPgInt32 = () =>
+    zCoercedWholeNumber().max(PG_INT32_MAX, {
+        message: `Must be at most ${PG_INT32_MAX}`
+    })
 
 export const zPage = () => z.coerce.number().int().positive().default(1)
 
@@ -41,8 +53,13 @@ export const zDateString = <N extends boolean = false>({
 export const zDigitString = () =>
     z.coerce.string().regex(/^\d+n?$/) as ZodType<string, ZodStringDef, number | string | bigint>
 
-// Input param that will be coerced to a BigInt
-export const zBigIntString = () => zDigitString().transform(val => BigInt(val))
+// Input param that will be coerced to a BigInt within PostgreSQL BIGINT range
+export const zBigIntString = () =>
+    zDigitString()
+        .transform(val => BigInt(val))
+        .refine(val => val <= PG_BIGINT_MAX, {
+            message: `Must be at most ${PG_BIGINT_MAX}`
+        })
 
 export const zSplitCommaSeparatedString = <T extends ZodTypeAny, ResultingArray extends ZodTypeAny>(
     itemSchema: T,

--- a/src/services/reporting/update-blacklist.ts
+++ b/src/services/reporting/update-blacklist.ts
@@ -14,7 +14,7 @@ export const blacklistInstance = async (data: {
         const reportSource = data.reportId ? "WebReport" : "Manual"
         await conn.queryRow(
             `INSERT INTO flagging.blacklist_instance (instance_id, report_source, report_id, reason)
-            VALUES ($1::bigint, $2, $3, $4)
+            VALUES ($1::bigint, $2::flagging."BlacklistReportSource", $3, $4)
             ON CONFLICT (instance_id) DO NOTHING`,
             { params: [data.instanceId, reportSource, data.reportId, data.reason] }
         )


### PR DESCRIPTION
## Summary
- Reject membership IDs above PostgreSQL `BIGINT` max and duration filters above `INTEGER` max at route validation, returning 400 instead of unhandled DB errors (Fixes API-12, API-1A, API-1K, API-1Q).
- Schema-qualify `flagging."BlacklistReportSource"` on admin blacklist inserts so prod Postgres finds the enum type (Fixes API-1M).

## Sentry issues addressed
| Issue | Error | Fix |
|-------|-------|-----|
| API-12 / API-1Q | `value "10000000000" is out of range for type integer` | `zPgInt32()` on `minDurationSeconds` / `maxDurationSeconds` |
| API-1A | `value "46116860184306851060" is out of range for type bigint` | `zBigIntString()` capped at `PG_BIGINT_MAX` |
| API-1M | `type "BlacklistReportSource" does not exist` | Explicit `::flagging."BlacklistReportSource"` cast in INSERT |

## Test plan
- [x] `bun test src/schema/input.test.ts`
- [x] `bun run typecheck`
- [ ] CI green
- [ ] After deploy: confirm API-12/API-1A return 400 validation errors instead of 500 for bad inputs


Made with [Cursor](https://cursor.com)