### PR TITLE
Pantheon community race leaderboard snapshot (API)

### DIFF
--- a/src/services/instance/instance.ts
+++ b/src/services/instance/instance.ts
@@ -210,9 +210,8 @@ export const getLeaderboardEntryForInstance = async (instanceId: bigint | string
             rank: number
         }>(
             `SELECT rank::int
-            FROM team_pantheon_custom_race_leaderboard
+            FROM pantheon_custom_race_snapshot
             WHERE instance_id = $1::bigint
-            ORDER BY rank ASC
             LIMIT 1;`,
             { params: [instanceId] }
         )
@@ -227,6 +226,17 @@ export const getLeaderboardEntryForInstance = async (instanceId: bigint | string
         ) {
             throw error
         }
+
+        customRaceEntry = await pgReader.queryRow<{
+            rank: number
+        }>(
+            `SELECT rank::int
+            FROM team_pantheon_custom_race_leaderboard
+            WHERE instance_id = $1::bigint
+            ORDER BY rank ASC
+            LIMIT 1;`,
+            { params: [instanceId] }
+        )
     }
 
     if (!versionEntry) {

--- a/src/services/leaderboard/team/custom.ts
+++ b/src/services/leaderboard/team/custom.ts
@@ -5,21 +5,16 @@ import { TeamLeaderboardEntry } from "@/schema/components/LeaderboardData"
 /** Insurrection Prime Revolutionary (version 134) — final pantheon community raid race. */
 export const PANTHEON_COMMUNITY_RACE_VERSION_ID = 134
 
-export const getPantheonCustomRaceTeamLeaderboard = async ({
-    skip,
-    take
-}: {
-    skip: number
-    take: number
-}) => {
-    return await pgReader.queryRows<TeamLeaderboardEntry>(
-        `SELECT
-            position::int,
-            rank::int,
-            value,
-            instance_id as "instanceId",
-            "lateral".players
-        FROM team_pantheon_custom_race_leaderboard
+const PANTHEON_RACE_SNAPSHOT = "pantheon_custom_race_snapshot"
+const PANTHEON_RACE_LEGACY_MV = "team_pantheon_custom_race_leaderboard"
+
+const isMissingRelation = (error: unknown) =>
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code: string }).code === "42P01"
+
+const pantheonRacePlayerLateral = (source: string) => `
         LEFT JOIN LATERAL (
             SELECT 
                 COALESCE(
@@ -40,20 +35,50 @@ export const getPantheonCustomRaceTeamLeaderboard = async ({
                 ) as "players"
             FROM instance_player
             INNER JOIN player USING (membership_id)
-            WHERE instance_player.instance_id = team_pantheon_custom_race_leaderboard.instance_id
+            WHERE instance_player.instance_id = ${source}.instance_id
                 AND instance_player.completed
-        ) as "lateral" ON true
+        ) as "lateral" ON true`
+
+const withPantheonRaceSource = async <T>(run: (source: string) => Promise<T>): Promise<T> => {
+    try {
+        return await run(PANTHEON_RACE_SNAPSHOT)
+    } catch (error) {
+        if (isMissingRelation(error)) {
+            return await run(PANTHEON_RACE_LEGACY_MV)
+        }
+        throw error
+    }
+}
+
+export const getPantheonCustomRaceTeamLeaderboard = async ({
+    skip,
+    take
+}: {
+    skip: number
+    take: number
+}) => {
+    return await withPantheonRaceSource(source =>
+        pgReader.queryRows<TeamLeaderboardEntry>(
+            `SELECT
+            position::int,
+            rank::int,
+            value,
+            instance_id as "instanceId",
+            "lateral".players
+        FROM ${source}
+        ${pantheonRacePlayerLateral(source)}
         WHERE position > $1 AND position <= ($1 + $2)
         ORDER BY position ASC`,
-        {
-            params: [skip, take],
-            transformers: {
-                players: {
-                    membershipId: convertStringToBigInt,
-                    lastSeen: convertStringToDate
+            {
+                params: [skip, take],
+                transformers: {
+                    players: {
+                        membershipId: convertStringToBigInt,
+                        lastSeen: convertStringToDate
+                    }
                 }
             }
-        }
+        )
     )
 }
 
@@ -64,14 +89,34 @@ export const searchPantheonCustomRaceTeamLeaderboard = async ({
     membershipId: bigint | string
     take: number
 }) => {
-    const result = await pgReader.queryRow<{ position: number }>(
-        `SELECT position::int
-        FROM team_pantheon_custom_race_leaderboard
-        WHERE membership_ids @> $1::jsonb
-        ORDER BY position ASC
-        LIMIT 1`,
-        { params: [`${[membershipId]}`] }
-    )
+    const result = await withPantheonRaceSource(async source => {
+        if (source === PANTHEON_RACE_SNAPSHOT) {
+            return await pgReader.queryRow<{ position: number }>(
+                `SELECT s.position::int
+                FROM pantheon_custom_race_snapshot s
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM instance_player ip
+                    WHERE ip.instance_id = s.instance_id
+                        AND ip.membership_id = $1::bigint
+                        AND ip.completed
+                )
+                ORDER BY s.position ASC
+                LIMIT 1`,
+                { params: [membershipId] }
+            )
+        }
+
+        return await pgReader.queryRow<{ position: number }>(
+            `SELECT position::int
+            FROM team_pantheon_custom_race_leaderboard
+            WHERE membership_ids @> $1::jsonb
+            ORDER BY position ASC
+            LIMIT 1`,
+            { params: [`${[membershipId]}`] }
+        )
+    })
+
     if (!result) return null
 
     const page = Math.ceil(result.position / take)


### PR DESCRIPTION
## Summary

- Read the pantheon community race leaderboard from `pantheon_custom_race_snapshot` instead of the live `team_pantheon_custom_race_leaderboard` materialized view.
- Falls back to the legacy MV when the snapshot table is missing (`42P01`), so this can deploy safely before or after the DB migration.
- Companion: Raid-Hub/Services (migration 012/013 — snapshot table + MV drop).

## Rollout (no downtime)

Apply in this order. Each step is safe to pause between.

### Step 1 — Prod SQL: create snapshot (before any deploy)

Run the contents of `RaidHub-Services/infrastructure/postgres/migrations/012_pantheon_custom_race_snapshot.sql` on prod.

- Creates `leaderboard.pantheon_custom_race_snapshot` and seeds 110 frozen rows.
- **Does not drop** the MV. Current prod API keeps working unchanged.

Dry-run after apply:

```sql
SELECT COUNT(*) FROM leaderboard.pantheon_custom_race_snapshot; -- expect 110
SELECT COUNT(*) FROM leaderboard.team_pantheon_custom_race_leaderboard; -- still 110
```

### Step 2 — Deploy this API PR

- API reads snapshot first; MV remains as fallback.
- Leaderboard immediately serves frozen standings once step 1 is applied.
- If step 1 is not applied yet, API continues using the MV (no breakage).

Smoke test:

```bash
curl -s "https://api.raidhub.io/leaderboard/team/custom/pantheon-community-race?page=1&count=5" -H "X-API-KEY: ..."
```

### Step 3 — Prod SQL: drop legacy MV

Run `RaidHub-Services/infrastructure/postgres/migrations/013_drop_pantheon_custom_race_leaderboard.sql`:

```sql
DROP MATERIALIZED VIEW IF EXISTS leaderboard.team_pantheon_custom_race_leaderboard;
```

Safe once step 2 is deployed — API no longer depends on the MV.

### Step 4 — Deploy Services PR

- Cheat detection joins `pantheon_custom_race_snapshot` instead of the MV.
- Removes the 3-minute pantheon MV cron entry.
- Hermes restart optional (cheat-detection join only affects blacklist cascade scope).

### Step 5 — Prod SQL: blacklist cleanup

Dry-run:

```sql
SELECT COUNT(*) FROM flagging.blacklist_instance bi
WHERE bi.report_source = 'Manual'
  AND bi.instance_id NOT IN (SELECT instance_id FROM leaderboard.pantheon_custom_race_snapshot)
  AND bi.reason NOT ILIKE '%cheat%'
  AND bi.reason NOT ILIKE '%cheater%'
  AND EXISTS (
    SELECT 1 FROM core.instance i
    JOIN definitions.activity_version av ON av.hash = i.hash
    WHERE i.instance_id = bi.instance_id
      AND av.version_id = 134
      AND i.date_completed >= '2026-06-13 17:00:00+00'::timestamptz
      AND i.date_completed < '2026-06-15 17:00:00+00'::timestamptz
  );
-- expect ~52
```

Apply:

```sql
BEGIN;
DELETE FROM flagging.blacklist_instance bi
WHERE bi.report_source = 'Manual'
  AND bi.instance_id NOT IN (SELECT instance_id FROM leaderboard.pantheon_custom_race_snapshot)
  AND bi.reason NOT ILIKE '%cheat%'
  AND bi.reason NOT ILIKE '%cheater%'
  AND EXISTS (
    SELECT 1 FROM core.instance i
    JOIN definitions.activity_version av ON av.hash = i.hash
    WHERE i.instance_id = bi.instance_id
      AND av.version_id = 134
      AND i.date_completed >= '2026-06-13 17:00:00+00'::timestamptz
      AND i.date_completed < '2026-06-15 17:00:00+00'::timestamptz
  );
COMMIT;
```

Removes LB-only manual blacklists for race-window instances not on the frozen standings. Cheat-marked manual blacklists are kept.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test src/routes/leaderboard/team/custom.test.ts`
- [ ] After step 1+2 on prod: spot-check `/leaderboard/team/custom/pantheon-community-race` and a known finisher profile PGCR rank badge


Made with [Cursor](https://cursor.com)